### PR TITLE
Implement async auth callbacks

### DIFF
--- a/solution.md
+++ b/solution.md
@@ -12,3 +12,10 @@ closed.
 
 Tests were extended to exercise the new behaviour and the concurrency test was
 skipped because it requires additional heavy dependencies.
+
+### Asynchronous Authentication
+
+Authentication now uses the same worker-thread mechanism as query handling.
+The Python callback receives an extra argument – a callback object – and must
+invoke it with a boolean result.  This keeps the server non-blocking while
+waiting for credentials to be validated inside Python.


### PR DESCRIPTION
## Summary
- support auth callbacks via the background Python worker
- expose `AUTH_WITH_CALLBACK` constant for tests
- update tests to use async auth callback and rebuild wheel when needed

## Testing
- `python -m pytest -q`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683f5e713780832fbb44c947635a771c