### PR TITLE
Fix Arrow IPC callback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,14 @@ Contributions are welcome! Especially for:
 
 Because you're riffing on SQL. You don’t just store it — you remix it.
 
+## Development Notes
+
+This repository contains tests that exercise the ability to return query results
+as Arrow IPC streams from Python. The initial implementation in `src/lib.rs`
+only accepted raw bytes without decoding them, resulting in empty result sets.
+
+The code now invokes `pyarrow` to parse these IPC bytes back into ordinary
+rows.  The parsing is performed inside the Rust callback while holding the
+Python GIL so no additional Rust Arrow dependencies are required.
+
 ---


### PR DESCRIPTION
## Summary
- parse Arrow IPC byte streams using `pyarrow`
- extend test server with boolean column support
- document Arrow IPC handling in README

## Testing
- `cargo test --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyarrow')*

------
https://chatgpt.com/codex/tasks/task_e_683f5a898978832fab2f3c03e844f937