### PR TITLE
Fix GitHub actions step names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,40 +7,56 @@ on:
     branches: ["**"]
 
 jobs:
-  build-and-test:
+  unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
-      - run: cargo test --verbose
-      - run: pip install -r requirements.txt
-      - run: pip install maturin
-      - run: maturin build --release -i python3
-      - run: pip install target/wheels/*.whl
-      - run: python -m unittest discover -s tests
+      - name: Run Rust tests
+        run: cargo test --verbose
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+      - name: Install maturin
+        run: pip install maturin
+      - name: Build Python wheel
+        run: maturin build --release -i python3
+      - name: Install wheel
+        run: pip install target/wheels/*.whl
+      - name: Run Python unit tests
+        run: python -m unittest discover -s tests
 
-  disabled-tests:
-    if: github.event_name == 'pull_request'
+  concurrency-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
-      - run: pip install -r requirements.txt
-      - run: pip install maturin psycopg2-binary
-      - run: maturin build --release -i python3
-      - run: pip install target/wheels/*.whl
-      - run: python test_concurrency/test_concurrency_duckdb.py
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Install maturin and Postgres dependencies
+        run: pip install maturin psycopg2-binary
+      - name: Build Python wheel
+        run: maturin build --release -i python3
+      - name: Install wheel
+        run: pip install target/wheels/*.whl
+      - name: Run concurrency tests
+        run: python test_concurrency/test_concurrency_duckdb.py


### PR DESCRIPTION
## Summary
- improve naming of steps in CI workflow
- run all tests in GitHub Actions

## Testing
- `cargo test`
- `python -m unittest discover -s tests`
- `python test_concurrency/test_concurrency_duckdb.py`


------
https://chatgpt.com/codex/tasks/task_e_683f88ca6ef0832fa72a94832f87844c