### PR TITLE
Zero-copy Arrow experiment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,9 @@ name = "arrow-schema"
 version = "55.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73a47aa0c771b5381de2b7f16998d351a6f4eb839f1e13d48353e17e873d969b"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "arrow-select"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ futures = "0.3"
 async-trait = "0.1"
 hex = "0.4.3"
 postgres-types = "0.2"
-arrow = "55.1.0"
+arrow = { version = "55.1.0", features = ["ffi"] }

--- a/duckdb_arrow_sample.py
+++ b/duckdb_arrow_sample.py
@@ -2,10 +2,21 @@
 
 import duckdb
 import pyarrow as pa
+import ctypes
 
 # Execute a query and fetch results as Arrow
 con = duckdb.connect()
 record_batch = con.execute("SELECT 1 AS a, 'foo' AS b").fetch_record_batch()
 
-# 'record_batch' is a pyarrow.RecordBatch. It can be sent to the Rust layer
-print(record_batch)
+# Export as an Arrow C Stream pointer for zero-copy transfer
+reader = pa.RecordBatchReader.from_batches(record_batch.schema, [record_batch])
+if hasattr(reader, "__arrow_c_stream__"):
+    capsule = reader.__arrow_c_stream__()
+    stream_ptr = ctypes.cast(capsule, ctypes.c_void_p).value
+else:
+    from pyarrow.cffi import ffi
+    c_stream = ffi.new("struct ArrowArrayStream*")
+    reader._export_to_c(c_stream)
+    stream_ptr = int(ffi.cast("uintptr_t", c_stream))
+
+print("Arrow stream pointer:", stream_ptr)


### PR DESCRIPTION
## Summary
- enable `ffi` feature on Arrow crate
- attempt zero-copy arrow stream transfer in CallbackWrapper
- update DuckDB example to share Arrow stream pointer
- modify test server to send Arrow stream capsule or pointer

## Testing
- `cargo test --quiet`
- `pytest -q` *(fails: Worker failed due to RecvError)*


------
https://chatgpt.com/codex/tasks/task_e_684299302344832fac993854f86c61c9