### PR TITLE
Add TLS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ def handle_sql(sql: str):
 riffq.serve(port=5432)
 ```
 
+### Enabling TLS
+
+Generate a temporary certificate and key:
+
+```bash
+openssl req -newkey rsa:2048 -nodes -keyout server.key -x509 -days 1 -out server.crt -subj "/CN=localhost"
+```
+
+Start the server with TLS enabled:
+
+```python
+server = riffq.Server("127.0.0.1:5432")
+server.set_tls("server.crt", "server.key")
+server.start(tls=True)
+```
+
 Then connect using any PostgreSQL client:
 
 ```bash
@@ -89,7 +105,7 @@ psql -h localhost -p 5432
 - ✅ Query dispatching to Python
 - ✅ DuckDB, Pandas, Polars compatibility
 - 🟡 Limited SQL parsing on Rust side (forwarded to Python)
-- ❌ No authentication or TLS (yet)
+- ✅ Optional TLS encryption
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 psycopg[binary]
+psycopg2-binary
 sqlalchemy
 maturin
 duckdb


### PR DESCRIPTION
## Summary
- document how to enable TLS in the README
- show TLS support in status table
- add psycopg2-binary dependency for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842dc167fec832f80d4450ceea7c73b