### PR TITLE
Add connection identifiers and tests

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,14 +11,7 @@ import pyarrow as pa
 
 
 def _ensure_riffq_built():
-    try:
-        import riffq  # noqa: F401
-
-        return
-    except ImportError:
-        pass
-
-    # Attempt to build the extension from source
+    subprocess.call([sys.executable, "-m", "pip", "uninstall", "-y", "riffq"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     try:
         subprocess.check_call(["maturin", "build", "--release", "-q"])
         wheel = next(Path("target/wheels").glob("riffq-*.whl"))


### PR DESCRIPTION
## Summary
- track each connection with an incrementing ID
- expose the connection ID to Python callbacks
- ensure Python callbacks see `connection_id`
- test that connection IDs are unique and incrementing
- force rebuilding the wheel in tests to pick up code changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684452a376b8832fac211a5a55552918
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a unique, incrementing connection ID for each client connection and exposed it to Python callbacks. Added tests to ensure connection IDs are unique and incrementing.

- **Testing**
  - Added tests for connection ID uniqueness and incrementing.
  - Updated test setup to always rebuild the wheel before running tests.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Each client is now assigned a unique connection ID, which is accessible during queries and can be used by Python callbacks.
- **Tests**
  - Added comprehensive tests to verify unique connection ID assignment for sequential and parallel client connections.
  - Improved test setup to ensure the server package is rebuilt and reinstalled for each test run.
- **Chores**
  - Updated test infrastructure to always rebuild and reinstall the server package before tests, ensuring a clean environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->