### PR TITLE
Add on_connect callback and rename query handler

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -64,7 +64,7 @@ def _run_server(port: int):
         send_batch(batch, callback)
 
     server = riffq.Server(f"127.0.0.1:{port}")
-    server.set_callback(handle_query)
+    server.on_query(handle_query)
     server.start()
 
 class ServerTest(unittest.TestCase):

--- a/tests/test_server_tls.py
+++ b/tests/test_server_tls.py
@@ -39,7 +39,7 @@ def _run_server_tls(port: int, cert: str, key: str):
         callback(([{"name": "val", "type": "int"}], [[value]]))
 
     server = riffq.Server(f"127.0.0.1:{port}")
-    server.set_callback(handle_query)
+    server.on_query(handle_query)
     server.set_tls(cert, key)
     server.start(tls=True)
 


### PR DESCRIPTION
## Summary
- add Python worker message enum for connection events
- implement `on_connect` callback and rename `set_callback` -> `on_query`
- expose callbacks in Rust and call them from server
- update tests to use new `on_query` and add test for connection rejection

## Testing
- `cargo test`
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_684462da14e4832f9d3a66f484a64d98