### PR TITLE
Update concurrency tests for new on_query callback

### DIFF
--- a/test_concurrency/server.py
+++ b/test_concurrency/server.py
@@ -114,7 +114,7 @@ def main():
     executor = ThreadPoolExecutor(max_workers=4)
 
     server = riffq.Server("127.0.0.1:5433")
-    server.set_callback(handle_query)
+    server.on_query(handle_query)
     server.start()
 
 

--- a/test_concurrency/server_duckdb_arrow.py
+++ b/test_concurrency/server_duckdb_arrow.py
@@ -94,7 +94,7 @@ def main():
     executor = ThreadPoolExecutor(max_workers=4)
 
     server = riffq.Server("127.0.0.1:5433")
-    server.set_callback(handle_query)
+    server.on_query(handle_query)
     server.start()
 
 if __name__ == "__main__":

--- a/test_concurrency/server_polars.py
+++ b/test_concurrency/server_polars.py
@@ -104,7 +104,7 @@ def main():
         "value": ["value1", "value2", "value3"]
     })
     server = riffq.Server("127.0.0.1:5433")
-    server.set_callback(handle_query)
+    server.on_query(handle_query)
     server.start()
 
 if __name__ == "__main__":

--- a/try_pg.py
+++ b/try_pg.py
@@ -40,5 +40,5 @@ def handle_query(sql, callback, **kwargs):
 
 if __name__ == "__main__":
     server = riffq.Server("127.0.0.1:5433")
-    server.set_callback(handle_query)
+    server.on_query(handle_query)
     server.start()


### PR DESCRIPTION
## Summary
- update concurrency server helpers to use `on_query`
- replace `set_callback` usages in example script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845405eeefc832fbff015ea6b11a060
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated concurrency server helpers and example script to use the new on_query callback instead of set_callback.

<!-- End of auto-generated description by cubic. -->

