### PR TITLE
Add authentication handler

### DIFF
--- a/tests/test_on_authentication.py
+++ b/tests/test_on_authentication.py
@@ -1,0 +1,73 @@
+import multiprocessing
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import psycopg
+import unittest
+
+
+def _ensure_riffq_built():
+    subprocess.call([sys.executable, "-m", "pip", "uninstall", "-y", "riffq"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        subprocess.check_call(["maturin", "build", "--release", "-q"])
+        wheel = next(Path("target/wheels").glob("riffq-*.whl"))
+        subprocess.check_call([sys.executable, "-m", "pip", "install", str(wheel)])
+    except Exception as exc:
+        raise RuntimeError(f"riffq build failed: {exc}")
+
+
+def _run_server(port: int):
+    import riffq
+
+    def handle_query(sql, callback, **kwargs):
+        callback(([{"name": "val", "type": "int"}], [[1]]))
+
+    def handle_auth(conn_id, user, password, host, database=None):
+        return user == "user" and password == "secret"
+
+    server = riffq.Server(f"127.0.0.1:{port}")
+    server.on_query(handle_query)
+    server.on_authentication(handle_auth)
+    server.start()
+
+
+class AuthenticationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_riffq_built()
+        cls.port = 55438
+        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port,), daemon=True)
+        cls.proc.start()
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            cls.proc.terminate()
+            cls.proc.join()
+            raise RuntimeError("Server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+
+    def test_auth_reject(self):
+        with self.assertRaises(psycopg.OperationalError):
+            psycopg.connect(f"postgresql://user:wrong@127.0.0.1:{self.port}/db")
+
+    def test_auth_accept(self):
+        conn = psycopg.connect(f"postgresql://user:secret@127.0.0.1:{self.port}/db")
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1")
+            self.assertEqual(cur.fetchone()[0], 1)
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `on_authentication` callback and worker message
- extend server to support authentication hook
- add Python test for authentication callback

## Testing
- `cargo check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68455c444220832fad80a5cc000945c1
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an authentication handler with a new on_authentication callback, allowing custom authentication logic in the server.

- **New Features**
  - Added on_authentication callback to the server API.
  - Extended server to support authentication hooks.
  - Added Python tests for authentication callback behavior.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authentication support, allowing the server to validate user credentials via Python callbacks.
- **Tests**
  - Introduced tests to verify authentication behavior, including acceptance of valid credentials and rejection of invalid ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->