### PR TITLE
Add callbacks for connection and authentication events

### DIFF
--- a/tests/test_on_authentication.py
+++ b/tests/test_on_authentication.py
@@ -15,8 +15,8 @@ def _run_server(port: int):
     def handle_query(sql, callback, **kwargs):
         callback(([{"name": "val", "type": "int"}], [[1]]))
 
-    def handle_auth(conn_id, user, password, host, database=None):
-        return user == "user" and password == "secret"
+    def handle_auth(conn_id, user, password, host, *, callback, database=None):
+        callback(user == "user" and password == "secret")
 
     server = riffq.Server(f"127.0.0.1:{port}")
     server.on_query(handle_query)

--- a/tests/test_on_connect.py
+++ b/tests/test_on_connect.py
@@ -15,8 +15,8 @@ def _run_server(port: int):
     def handle_query(sql, callback, **kwargs):
         callback(([{"name": "val", "type": "int"}], [[1]]))
 
-    def handle_connect(conn_id, ip, port):
-        return False
+    def handle_connect(conn_id, ip, port, *, callback):
+        callback(False)
 
     server = riffq.Server(f"127.0.0.1:{port}")
     server.on_query(handle_query)


### PR DESCRIPTION
## Summary
- support async results for connection and authentication callbacks by passing a `callback` kwarg
- implement new `BoolCallbackWrapper` in Rust
- adapt tests to use the new callback parameter

## Testing
- `pytest tests/test_on_connect.py::OnConnectTest::test_reject -q`
- `pytest tests/test_on_authentication.py::AuthenticationTest::test_auth_accept tests/test_on_authentication.py::AuthenticationTest::test_auth_reject -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456e610f9c832f8ca05535de6113c6
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added async callback support for connection and authentication events, allowing handlers to use a callback parameter instead of returning a value.

- **New Features**
  - Added a callback parameter to connection and authentication handlers.
  - Introduced a BoolCallbackWrapper in Rust to handle async results.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for asynchronous callback handling for connection and authentication events, allowing Python callbacks to receive a callback argument and respond asynchronously.

- **Refactor**
  - Updated authentication and connection handler functions to use a callback-based approach instead of returning boolean values directly. Handlers now invoke the callback with the result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->