### PR TITLE
Fix concurrency polars test

### DIFF
--- a/test_concurrency/server_polars.py
+++ b/test_concurrency/server_polars.py
@@ -94,7 +94,9 @@ def main():
     global test_concurrency_df, heavy_df
 
     heavy_df = pl.DataFrame({
-        "x": list(range(155_000_000))
+        # reduced range to keep memory usage reasonable while
+        # still providing a noticeably heavy query
+        "x": list(range(10_000_000))
     })
 
     test_concurrency_df = pl.DataFrame({
@@ -103,7 +105,7 @@ def main():
         "key": ["alpha", "beta", "gamma"],
         "value": ["value1", "value2", "value3"]
     })
-    server = riffq.Server("127.0.0.1:5433")
+    server = riffq.Server("127.0.0.1:5434")
     server.on_query(handle_query)
     server.start()
 

--- a/test_concurrency/test_concurrency_polars.py
+++ b/test_concurrency/test_concurrency_polars.py
@@ -16,13 +16,10 @@ def start_polars_server():
 
 def run_heavy_query():
     logging.info("sending long running query")
-    engine = create_engine("postgresql://myuser:mypassword@127.0.0.1:5433/mydb")
+    engine = create_engine("postgresql://myuser:mypassword@127.0.0.1:5434/mydb")
     with engine.connect() as conn:
-        conn.execute(text("""
-            SELECT SUM(a.id * b.id)
-            FROM range(0, 100000) AS a(id),
-                 range(0, 10000) AS b(id)
-        """))
+        # trigger the heavy Polars computation
+        conn.execute(text("SELECT heavy_query"))
     logging.info("finished long running query")
 
 
@@ -39,7 +36,7 @@ class TestPolarsConcurrency(unittest.TestCase):
         cls.server_proc.join()
 
     def test_concurrent_queries(self):
-        engine = wait_for_server()
+        engine = wait_for_server(port=5434)
         
         fast_query_times = []
 

--- a/test_concurrency/utils.py
+++ b/test_concurrency/utils.py
@@ -1,8 +1,8 @@
 from sqlalchemy import create_engine, text
 import time
 
-def wait_for_server():
-    engine = create_engine("postgresql://myuser:mypassword@127.0.0.1:5433/mydb")
+def wait_for_server(port: int = 5433):
+    engine = create_engine(f"postgresql://myuser:mypassword@127.0.0.1:{port}/mydb")
     import sqlalchemy.exc
     cnt = 0
     while True:


### PR DESCRIPTION
## Summary
- reduce size of heavy DataFrame in polars server
- run polars server on its own port and update test utilities
- query `SELECT heavy_query` so the heavy computation runs reliably

## Testing
- `pytest -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_684713d884b0832f9d171674acafffc1
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reduced the size of the heavy DataFrame in the Polars server and moved it to its own port to avoid conflicts. Updated tests and utilities to use the new port and trigger the heavy computation reliably.

- **Bug Fixes**
  - Lowered memory usage by shrinking the DataFrame.
  - Changed test queries to use a dedicated heavy query.
  - Updated test utilities to support custom ports.

<!-- End of auto-generated description by cubic. -->

