### PR TITLE
Use log crate for Rust server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,6 +1626,7 @@ dependencies = [
  "chrono",
  "futures",
  "hex",
+ "log",
  "pgwire",
  "postgres-types",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ rustls-pemfile = "2"
 rustls-pki-types = "1"
 arrow = { version = "55.1.0", features = ["ffi"] }
 chrono = "0.4.41"
+log = "0.4"
 


### PR DESCRIPTION
## Summary
- switch Rust print statements to use the `log` crate
- add `log` dependency

## Testing
- `cargo check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684728bf5508832f9092b447e861a6cd
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced all Rust print statements with logging using the log crate for better log management.

- **Dependencies**
  - Added log as a new dependency.

<!-- End of auto-generated description by cubic. -->

