### PR TITLE
Fix compilation after pg_catalog integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,6 +3083,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "datafusion",
  "datafusion_pg_catalog",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,6 @@ rustls-pki-types = "1"
 arrow = { version = "55.1.0", features = ["ffi"] }
 chrono = "0.4.41"
 log = "0.4"
-pg_catalog = { git = "https://github.com/ybrs/pg_catalog", branch = "main", package = "datafusion_pg_catalog" }
+datafusion = "47.0.0"
+datafusion_pg_catalog = { git = "https://github.com/ybrs/pg_catalog", branch = "main", package = "datafusion_pg_catalog" }
 

--- a/integrate_pg_catalog.md
+++ b/integrate_pg_catalog.md
@@ -31,3 +31,27 @@ See `pg_catalog/example/src/main.rs` for the complete flow.
 `riffq` was updated to fetch the latest `datafusion_pg_catalog` and a `SessionContext` is created on server start. Query execution was routed through `dispatch_query` so that statements referencing `pg_catalog` are handled internally. Python query results were converted to and from Arrow `RecordBatch` values for compatibility.
 
 However, catalog queries still returned the fallback value from the Python handler. Manual tests showed `SELECT datname FROM pg_catalog.pg_database` returning `1` instead of the expected string, indicating the router did not recognise the catalog tables in the context. Due to time limits this issue could not be resolved.
+
+## Fixing compilation
+
+After the initial attempt the project no longer compiled with `maturin build`.
+The errors were mainly caused by missing dependencies and API changes in
+`arrow`.  `datafusion` was not listed in `Cargo.toml` and the
+`datafusion_pg_catalog` crate was imported under the wrong name.  Furthermore
+`arrow` now expects `StringBuilder::new()` without a capacity and
+`append_value/append_null` no longer return a `Result`.
+
+Changes applied:
+
+* Added `datafusion = "47.0.0"` and renamed the pg catalog dependency to
+  `datafusion_pg_catalog`.
+* Updated `rows_to_record_batch` to use `StringBuilder::new()` and removed
+  `.unwrap()` on `append_value`/`append_null`.
+* Implemented `run_via_router` for `MyExtendedQueryHandler` mirroring the logic
+  in `RiffqProcessor`.
+* Adjusted closures passed to `dispatch_query` to own the SQL string in order to
+  satisfy lifetime requirements.
+
+With these tweaks `maturin build` now finishes successfully and produces the
+extension wheel.  Running the Python test-suite still fails as the server does
+not start correctly, but compilation issues are resolved.


### PR DESCRIPTION
## Summary
- add missing datafusion dependency and correct pg_catalog crate name
- update Arrow builder code for new APIs
- implement router logic for MyExtendedQueryHandler
- document compilation fixes

## Testing
- `maturin build`
- `pytest -q` *(fails: server did not start)*

------
https://chatgpt.com/codex/tasks/task_e_684e15f8ee20832face2cf7ebbd31c5f
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed compilation errors after integrating pg_catalog by updating dependencies, correcting crate names, and adjusting code for new Arrow APIs.

- **Bug Fixes**
  - Added missing datafusion dependency and fixed datafusion_pg_catalog import.
  - Updated Arrow StringBuilder usage for new API.
  - Implemented router logic for MyExtendedQueryHandler to restore query handling.

<!-- End of auto-generated description by cubic. -->

