### PR TITLE
Add pg catalog routing tests

### DIFF
--- a/tests/test_pg_catalog_query.py
+++ b/tests/test_pg_catalog_query.py
@@ -38,5 +38,20 @@ class PgCatalogTest(unittest.TestCase):
             self.assertIsInstance(row[0], str)
         conn.close()
 
+    def test_catalog_pg_class_query(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        with conn.cursor() as cur:
+            cur.execute("SELECT relname FROM pg_catalog.pg_class LIMIT 1")
+            row = cur.fetchone()
+            self.assertIsInstance(row[0], str)
+        conn.close()
+
+    def test_non_catalog_query(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        with conn.cursor() as cur:
+            cur.execute("SELECT 42")
+            self.assertEqual(cur.fetchone()[0], 42)
+        conn.close()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add tests for queries routed through `datafusion_pg_catalog` dispatcher
- ensure non-catalog queries still execute via Python handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eab3e3f2c832fa670fc79fafdbfe8
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added tests to verify that queries using the pg_catalog dispatcher are routed correctly, and that non-catalog queries still use the Python handler.

<!-- End of auto-generated description by cubic. -->

