### PR TITLE
Add caching to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -24,6 +33,12 @@ jobs:
           override: true
       - name: Run Rust tests
         run: cargo test --verbose
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
       - name: Install Python dependencies
         run: pip install -r requirements.txt
       - name: Install maturin


### PR DESCRIPTION
## Summary
- cache cargo and pip deps to reduce workflow time

## Testing
- `cargo test --quiet`
- `python -m unittest discover -s tests`
- `python -m unittest discover -s test_concurrency`


------
https://chatgpt.com/codex/tasks/task_e_684ee1f1077c832f819bd6ccb2555b5b