### PR TITLE
Add optional catalog emulation

### DIFF
--- a/tests/test_pg_catalog_query.py
+++ b/tests/test_pg_catalog_query.py
@@ -12,7 +12,7 @@ class PgCatalogTest(unittest.TestCase):
     def setUpClass(cls):
         _ensure_riffq_built()
         cls.port = 55434
-        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port,), daemon=True)
+        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port, True), daemon=True)
         cls.proc.start()
         start = time.time()
         while time.time() - start < 10:
@@ -51,6 +51,38 @@ class PgCatalogTest(unittest.TestCase):
         with conn.cursor() as cur:
             cur.execute("SELECT 42")
             self.assertEqual(cur.fetchone()[0], 42)
+        conn.close()
+
+
+class PgCatalogDisabledTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_riffq_built()
+        cls.port = 55439
+        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port, False), daemon=True)
+        cls.proc.start()
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            cls.proc.terminate()
+            cls.proc.join()
+            raise RuntimeError("Server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+
+    def test_catalog_query_fails(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        with conn.cursor() as cur:
+            cur.execute("SELECT relname FROM pg_catalog.pg_class LIMIT 1")
+            row = cur.fetchone()
+            self.assertIsInstance(row[0], int)
         conn.close()
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ import unittest
 import pyarrow as pa
 from helpers import _ensure_riffq_built
 
-def _run_server(port: int):
+def _run_server(port: int, catalog_emulation: bool = False):
     import riffq
     import pyarrow as pa
 
@@ -56,7 +56,7 @@ def _run_server(port: int):
 
     server = riffq.Server(f"127.0.0.1:{port}")
     server.on_query(handle_query)
-    server.start()
+    server.start(catalog_emulation=catalog_emulation)
 
 class ServerTest(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Summary
- allow enabling pg_catalog routing via `catalog_emulation` argument to `Server.start`
- add `QueryPath` enum to select routing implementation
- create tests verifying behaviour when catalog emulation is enabled/disabled

## Testing
- `pip install -r requirements.txt`
- `maturin build --release`
- `pip install --force-reinstall target/wheels/riffq-0.1.0-cp312-cp312-manylinux_2_38_x86_64.whl`
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_684ed9b83c8c832faa8f6c9b95ea5634
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an optional catalog emulation mode to the server, allowing pg_catalog queries to be routed through DataFusion when enabled.

- **New Features**
  - Added a catalog_emulation parameter to Server.start.
  - Updated query routing logic to support both direct and emulated catalog paths.
  - Added tests for both enabled and disabled catalog emulation.

<!-- End of auto-generated description by cubic. -->

