### PR TITLE
Implement zero_copy arrow path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ datafusion = "47.0.0"
 datafusion_pg_catalog = { git = "https://github.com/ybrs/pg_catalog", branch = "main", package = "datafusion_pg_catalog" }
 env_logger = "0.11.8"
 
+[features]
+default = []
+zero_copy = []
+


### PR DESCRIPTION
## Summary
- add `zero_copy` cargo feature
- support arrow record batches via new `QueryRunnerArrow` trait
- convert arrow results to rows with `arrow_to_pg_rows`
- gate simple and extended query paths behind `zero_copy`

## Testing
- `cargo check --no-default-features`
- `cargo check --features zero_copy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68502fe88fd4832f9fb5d08bbb99688c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new zero_copy feature that enables Arrow record batch query support for more efficient data handling.

- **New Features**
  - Introduced the zero_copy cargo feature flag.
  - Added QueryRunnerArrow trait for Arrow-based query execution.
  - Implemented Arrow-to-Postgres row conversion with arrow_to_pg_rows.
  - Gated query paths to use Arrow when zero_copy is enabled.

<!-- End of auto-generated description by cubic. -->

