### PR TITLE
Implement Arrow-only query runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,5 @@ datafusion = "47.0.0"
 datafusion_pg_catalog = { git = "https://github.com/ybrs/pg_catalog", branch = "main", package = "datafusion_pg_catalog" }
 env_logger = "0.11.8"
 
-[features]
-default = []
-zero_copy = []
+
 


### PR DESCRIPTION
## Summary
- remove `zero_copy` feature and Arrow/Text dual code paths
- simplify query execution to always use Arrow
- unify query runner traits
- drop obsolete string conversion helpers

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68505aaf85f8832fbb9bc75588b68ba9