### PR TITLE
Implement arrow path unification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,4 @@ datafusion = "47.0.0"
 datafusion_pg_catalog = { git = "https://github.com/ybrs/pg_catalog", branch = "main", package = "datafusion_pg_catalog" }
 env_logger = "0.11.8"
 
-[features]
-default = []
-zero_copy = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,18 +59,6 @@ use pgwire::api::stmt::{StoredStatement, NoopQueryParser};
 pub mod pg;
 use pg::arrow_type_to_pgwire;
 
-fn map_python_type_to_pgwire(t: &str) -> Type {
-    match t {
-        "int" => Type::INT8,
-        "float" => Type::FLOAT8,
-        "str" | "string" => Type::VARCHAR,
-        "bool" => Type::BOOL,
-        "date" => Type::DATE,
-        "datetime" => Type::TIMESTAMP,
-        _ => Type::VARCHAR,
-    }
-}
-
 fn map_arrow_type(dt: &DataType) -> &'static str {
     use DataType::*;
     match dt {
@@ -266,61 +254,6 @@ result_py = (schema_desc, rows)
     }
 }
 
-fn arrow_value_to_string(array: &dyn Array, row: usize) -> Option<String> {
-    if array.is_null(row) {
-        return None;
-    }
-    match array.data_type() {
-        DataType::Int8 => Some(array.as_primitive::<arrow::array::types::Int8Type>().value(row).to_string()),
-        DataType::Int16 => Some(array.as_primitive::<arrow::array::types::Int16Type>().value(row).to_string()),
-        DataType::Int32 => Some(array.as_primitive::<arrow::array::types::Int32Type>().value(row).to_string()),
-        DataType::Int64 => Some(array.as_primitive::<arrow::array::types::Int64Type>().value(row).to_string()),
-        DataType::UInt8 => Some(array.as_primitive::<arrow::array::types::UInt8Type>().value(row).to_string()),
-        DataType::UInt16 => Some(array.as_primitive::<arrow::array::types::UInt16Type>().value(row).to_string()),
-        DataType::UInt32 => Some(array.as_primitive::<arrow::array::types::UInt32Type>().value(row).to_string()),
-        DataType::UInt64 => Some(array.as_primitive::<arrow::array::types::UInt64Type>().value(row).to_string()),
-        DataType::Float32 => Some(array.as_primitive::<arrow::array::types::Float32Type>().value(row).to_string()),
-        DataType::Float64 => Some(array.as_primitive::<arrow::array::types::Float64Type>().value(row).to_string()),
-        DataType::Boolean => Some(array.as_boolean().value(row).to_string()),
-        DataType::Utf8 => Some(array.as_string::<i32>().value(row).to_string()),
-        DataType::LargeUtf8 => Some(array.as_string::<i64>().value(row).to_string()),
-        DataType::Date32 => {
-            let days = array.as_primitive::<arrow::array::types::Date32Type>().value(row) as i64;
-            let date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap() + Duration::days(days);
-            Some(date.format("%Y-%m-%d").to_string())
-        }
-        DataType::Date64 => {
-            let ms = array.as_primitive::<arrow::array::types::Date64Type>().value(row);
-            let dt = NaiveDateTime::from_timestamp_opt(ms / 1000, (ms % 1000 * 1_000_000) as u32).unwrap();
-            Some(dt.format("%Y-%m-%d %H:%M:%S").to_string())
-        }
-        DataType::Timestamp(unit, _) => {
-            let nanos: i128 = match unit {
-                TimeUnit::Second => {
-                    array.as_primitive::<TimestampSecondType>().value(row) as i128 * 1_000_000_000
-                }
-                TimeUnit::Millisecond => {
-                    array.as_primitive::<TimestampMillisecondType>().value(row) as i128 * 1_000_000
-                }
-                TimeUnit::Microsecond => {
-                    array.as_primitive::<TimestampMicrosecondType>().value(row) as i128 * 1_000
-                }
-                TimeUnit::Nanosecond => {
-                    array.as_primitive::<TimestampNanosecondType>().value(row) as i128
-                }
-            };
-            let secs = (nanos / 1_000_000_000) as i64;
-            let nsec = (nanos % 1_000_000_000) as u32;
-            let dt = NaiveDateTime::from_timestamp_opt(secs, nsec).unwrap();
-            Some(dt.format("%Y-%m-%d %H:%M:%S%.f").to_string())
-        }
-        _ => {
-            debug!("unknown data type");
-            Some("".to_string())
-        },
-    }
-}
-
 fn arrow_stream_to_rows(ptr: *mut c_void) -> Result<(Vec<HashMap<String, String>>, Vec<Vec<Option<String>>>), String> {
     unsafe {
         debug!("[RUST] arrow_stream_to_rows: ptr={:?}", ptr);
@@ -341,7 +274,49 @@ fn arrow_stream_to_rows(ptr: *mut c_void) -> Result<(Vec<HashMap<String, String>
             for i in 0..num_rows {
                 let mut row = Vec::new();
                 for col in batch.columns() {
-                    row.push(arrow_value_to_string(col.as_ref(), i));
+                    let val = if col.is_null(i) {
+                        None
+                    } else {
+                        match col.data_type() {
+                            DataType::Int8 => Some(col.as_primitive::<arrow::array::types::Int8Type>().value(i).to_string()),
+                            DataType::Int16 => Some(col.as_primitive::<arrow::array::types::Int16Type>().value(i).to_string()),
+                            DataType::Int32 => Some(col.as_primitive::<arrow::array::types::Int32Type>().value(i).to_string()),
+                            DataType::Int64 => Some(col.as_primitive::<arrow::array::types::Int64Type>().value(i).to_string()),
+                            DataType::UInt8 => Some(col.as_primitive::<arrow::array::types::UInt8Type>().value(i).to_string()),
+                            DataType::UInt16 => Some(col.as_primitive::<arrow::array::types::UInt16Type>().value(i).to_string()),
+                            DataType::UInt32 => Some(col.as_primitive::<arrow::array::types::UInt32Type>().value(i).to_string()),
+                            DataType::UInt64 => Some(col.as_primitive::<arrow::array::types::UInt64Type>().value(i).to_string()),
+                            DataType::Float32 => Some(col.as_primitive::<arrow::array::types::Float32Type>().value(i).to_string()),
+                            DataType::Float64 => Some(col.as_primitive::<arrow::array::types::Float64Type>().value(i).to_string()),
+                            DataType::Boolean => Some(col.as_boolean().value(i).to_string()),
+                            DataType::Utf8 => Some(col.as_string::<i32>().value(i).to_string()),
+                            DataType::LargeUtf8 => Some(col.as_string::<i64>().value(i).to_string()),
+                            DataType::Date32 => {
+                                let days = col.as_primitive::<arrow::array::types::Date32Type>().value(i) as i64;
+                                let date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap() + Duration::days(days);
+                                Some(date.format("%Y-%m-%d").to_string())
+                            }
+                            DataType::Date64 => {
+                                let ms = col.as_primitive::<arrow::array::types::Date64Type>().value(i);
+                                let dt = NaiveDateTime::from_timestamp_opt(ms / 1000, (ms % 1000 * 1_000_000) as u32).unwrap();
+                                Some(dt.format("%Y-%m-%d %H:%M:%S").to_string())
+                            }
+                            DataType::Timestamp(unit, _) => {
+                                let nanos: i128 = match unit {
+                                    TimeUnit::Second => col.as_primitive::<TimestampSecondType>().value(i) as i128 * 1_000_000_000,
+                                    TimeUnit::Millisecond => col.as_primitive::<TimestampMillisecondType>().value(i) as i128 * 1_000_000,
+                                    TimeUnit::Microsecond => col.as_primitive::<TimestampMicrosecondType>().value(i) as i128 * 1_000,
+                                    TimeUnit::Nanosecond => col.as_primitive::<TimestampNanosecondType>().value(i) as i128,
+                                };
+                                let secs = (nanos / 1_000_000_000) as i64;
+                                let nsec = (nanos % 1_000_000_000) as u32;
+                                let dt = NaiveDateTime::from_timestamp_opt(secs, nsec).unwrap();
+                                Some(dt.format("%Y-%m-%d %H:%M:%S%.f").to_string())
+                            }
+                            _ => Some(String::new()),
+                        }
+                    };
+                    row.push(val);
                 }
                 rows.push(row);
             }
@@ -350,29 +325,10 @@ fn arrow_stream_to_rows(ptr: *mut c_void) -> Result<(Vec<HashMap<String, String>
     }
 }
 
-fn record_batches_to_rows(batches: Vec<RecordBatch>, schema: Arc<Schema>) -> (Vec<HashMap<String, String>>, Vec<Vec<Option<String>>>) {
-    let mut schema_desc = Vec::new();
-    for field in schema.fields() {
-        let mut map = HashMap::new();
-        map.insert("name".to_string(), field.name().to_string());
-        map.insert("type".to_string(), map_arrow_type(field.data_type()).to_string());
-        schema_desc.push(map);
-    }
-    let mut rows = Vec::new();
-    for batch in batches {
-        let num_rows = batch.num_rows();
-        for i in 0..num_rows {
-            let mut row = Vec::new();
-            for col in batch.columns() {
-                row.push(arrow_value_to_string(col.as_ref(), i));
-            }
-            rows.push(row);
-        }
-    }
-    (schema_desc, rows)
-}
-
-fn rows_to_record_batch(schema_desc: &[HashMap<String, String>], rows: &[Vec<Option<String>>]) -> (Vec<RecordBatch>, Arc<Schema>) {
+fn rows_to_arrow_batches(
+    schema_desc: &[HashMap<String, String>],
+    rows: &[Vec<Option<String>>],
+) -> ArrowQueryResult {
     let fields: Vec<Field> = schema_desc
         .iter()
         .map(|c| Field::new(c.get("name").unwrap(), DataType::Utf8, true))
@@ -398,83 +354,134 @@ fn rows_to_record_batch(schema_desc: &[HashMap<String, String>], rows: &[Vec<Opt
     (vec![batch], schema)
 }
 
+fn encode_arrow_value(
+    encoder: &mut DataRowEncoder,
+    array: &dyn Array,
+    row: usize,
+) -> PgWireResult<()> {
+    if array.is_null(row) {
+        return encoder.encode_field::<Option<i32>>(&None);
+    }
+    match array.data_type() {
+        DataType::Int8 => {
+            let v = array.as_primitive::<arrow::array::types::Int8Type>().value(row) as i64;
+            encoder.encode_field(&Some(v))
+        }
+        DataType::Int16 => {
+            let v = array.as_primitive::<arrow::array::types::Int16Type>().value(row) as i64;
+            encoder.encode_field(&Some(v))
+        }
+        DataType::Int32 => {
+            let v = array.as_primitive::<arrow::array::types::Int32Type>().value(row) as i64;
+            encoder.encode_field(&Some(v))
+        }
+        DataType::Int64 => {
+            let v = array.as_primitive::<arrow::array::types::Int64Type>().value(row);
+            encoder.encode_field(&Some(v))
+        }
+        DataType::UInt8 => {
+            let v = array.as_primitive::<arrow::array::types::UInt8Type>().value(row) as i64;
+            encoder.encode_field(&Some(v))
+        }
+        DataType::UInt16 => {
+            let v = array.as_primitive::<arrow::array::types::UInt16Type>().value(row) as i64;
+            encoder.encode_field(&Some(v))
+        }
+        DataType::UInt32 => {
+            let v = array.as_primitive::<arrow::array::types::UInt32Type>().value(row) as i64;
+            encoder.encode_field(&Some(v))
+        }
+        DataType::UInt64 => {
+            let v = array.as_primitive::<arrow::array::types::UInt64Type>().value(row) as i64;
+            encoder.encode_field(&Some(v))
+        }
+        DataType::Float16 => {
+            let v = array.as_primitive::<arrow::array::types::Float16Type>().value(row).to_f32() as f64;
+            encoder.encode_field(&Some(v))
+        }
+        DataType::Float32 => {
+            let v = array.as_primitive::<arrow::array::types::Float32Type>().value(row) as f64;
+            encoder.encode_field(&Some(v))
+        }
+        DataType::Float64 => {
+            let v = array.as_primitive::<arrow::array::types::Float64Type>().value(row);
+            encoder.encode_field(&Some(v))
+        }
+        DataType::Boolean => {
+            let v = array.as_boolean().value(row);
+            encoder.encode_field(&Some(v))
+        }
+        DataType::Utf8 => {
+            let v = array.as_string::<i32>().value(row);
+            encoder.encode_field(&Some(v))
+        }
+        DataType::LargeUtf8 => {
+            let v = array.as_string::<i64>().value(row);
+            encoder.encode_field(&Some(v))
+        }
+        DataType::Date32 => {
+            let days = array.as_primitive::<arrow::array::types::Date32Type>().value(row) as i64;
+            let date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap() + Duration::days(days);
+            encoder.encode_field(&Some(date))
+        }
+        DataType::Date64 => {
+            let ms = array.as_primitive::<arrow::array::types::Date64Type>().value(row);
+            let dt = NaiveDateTime::from_timestamp_opt(ms / 1000, (ms % 1000 * 1_000_000) as u32).unwrap();
+            encoder.encode_field(&Some(dt.date()))
+        }
+        DataType::Timestamp(unit, _) => {
+            let nanos: i128 = match unit {
+                TimeUnit::Second => array.as_primitive::<TimestampSecondType>().value(row) as i128 * 1_000_000_000,
+                TimeUnit::Millisecond => array.as_primitive::<TimestampMillisecondType>().value(row) as i128 * 1_000_000,
+                TimeUnit::Microsecond => array.as_primitive::<TimestampMicrosecondType>().value(row) as i128 * 1_000,
+                TimeUnit::Nanosecond => array.as_primitive::<TimestampNanosecondType>().value(row) as i128,
+            };
+            let secs = (nanos / 1_000_000_000) as i64;
+            let nsec = (nanos % 1_000_000_000) as u32;
+            let dt = NaiveDateTime::from_timestamp_opt(secs, nsec).unwrap();
+            encoder.encode_field(&Some(dt))
+        }
+        _ => {
+            encoder.encode_field::<Option<i32>>(&None)
+        }
+    }
+}
+
+
 fn arrow_to_pg_rows(
     batches: Vec<RecordBatch>,
     schema: Arc<Schema>,
 ) -> (Arc<Vec<FieldInfo>>, impl Stream<Item = PgWireResult<DataRow>>) {
-    let (schema_desc, rows_list) = record_batches_to_rows(batches, schema.clone());
-    let mut fields = Vec::new();
-    for field in schema.fields() {
-        fields.push(FieldInfo::new(
-            field.name().clone().into(),
-            None,
-            None,
-            arrow_type_to_pgwire(field.data_type()),
-            FieldFormat::Text,
-        ));
-    }
+    let fields: Vec<FieldInfo> = schema
+        .fields()
+        .iter()
+        .map(|f| {
+            FieldInfo::new(
+                f.name().clone().into(),
+                None,
+                None,
+                arrow_type_to_pgwire(f.data_type()),
+                FieldFormat::Text,
+            )
+        })
+        .collect();
     let schema_arc = Arc::new(fields);
     let schema_ref = schema_arc.clone();
-    let desc_clone = schema_desc.clone();
-    let data_row_stream = futures::stream::iter(rows_list.into_iter()).map(move |row| {
-        let schema_desc = desc_clone.clone();
+    let batches: Vec<Arc<RecordBatch>> = batches.into_iter().map(Arc::new).collect();
+    let rows: Vec<(Arc<RecordBatch>, usize)> = batches
+        .iter()
+        .flat_map(|batch| (0..batch.num_rows()).map(move |i| (batch.clone(), i)))
+        .collect();
+    let data_row_stream = futures::stream::iter(rows.into_iter()).map(move |(batch, row)| {
         let mut encoder = DataRowEncoder::new(schema_ref.clone());
-        for (idx, val) in row.iter().enumerate() {
-            let col_type = schema_desc[idx].get("type").unwrap();
-            encode_value(&mut encoder, val, col_type)?;
+        for array in batch.columns() {
+            encode_arrow_value(&mut encoder, array.as_ref(), row)?;
         }
         encoder.finish()
     });
     (schema_arc, data_row_stream)
 }
 
-fn encode_value(
-    encoder: &mut DataRowEncoder,
-    value: &Option<String>,
-    col_type: &str,
-) -> PgWireResult<()> {
-    match col_type {
-        "int" => {
-            let v: Option<i64> = match value {
-                Some(v) => v.parse().ok(),
-                None => None,
-            };
-            encoder.encode_field(&v)
-        }
-        "float" => {
-            let v: Option<f64> = match value {
-                Some(v) => v.parse().ok(),
-                None => None,
-            };
-            encoder.encode_field(&v)
-        }
-        "bool" => {
-            let v: Option<bool> = value.as_ref().map(|v| match v.as_str() {
-                "t" | "true" | "1" => true,
-                _ => false,
-            });
-            encoder.encode_field(&v)
-        }
-        "date" => {
-            let v: Option<NaiveDate> = match value {
-                Some(v) => NaiveDate::parse_from_str(v, "%Y-%m-%d").ok(),
-                None => None,
-            };
-            encoder.encode_field(&v)
-        }
-        "datetime" => {
-            let v: Option<NaiveDateTime> = match value {
-                Some(v) => NaiveDateTime::parse_from_str(v, "%Y-%m-%d %H:%M:%S%.f").ok(),
-                None => None,
-            };
-            encoder.encode_field(&v)
-        }
-        _ => {
-            let v: Option<&str> = value.as_deref();
-            encoder.encode_field(&v)
-        }
-    }
-}
 
 pub struct PythonWorker {
     sender: Sender<WorkerMessage>,
@@ -703,25 +710,10 @@ trait QueryRunner: Send + Sync {
         param_types: Option<Vec<Type>>,
         do_describe: bool,
         connection_id: u64,
-    ) -> datafusion::error::Result<(Vec<HashMap<String, String>>, Vec<Vec<Option<String>>>)>;
-}
-
-type ArrowQueryResult = (Vec<RecordBatch>, Arc<Schema>);
-
-#[async_trait]
-trait QueryRunnerArrow: Send + Sync {
-    async fn execute_arrow(
-        &self,
-        query: String,
-        params: Option<Vec<Option<Bytes>>>,
-        param_types: Option<Vec<Type>>,
-        do_describe: bool,
-        connection_id: u64,
     ) -> datafusion::error::Result<ArrowQueryResult>;
 }
 
-trait QueryRunnerCombined: QueryRunner + QueryRunnerArrow {}
-impl<T: QueryRunner + QueryRunnerArrow + ?Sized> QueryRunnerCombined for T {}
+type ArrowQueryResult = (Vec<RecordBatch>, Arc<Schema>);
 
 struct RouterQueryRunner {
     py_worker: Arc<PythonWorker>,
@@ -731,35 +723,6 @@ struct RouterQueryRunner {
 #[async_trait]
 impl QueryRunner for RouterQueryRunner {
     async fn execute(
-        &self,
-        query: String,
-        params: Option<Vec<Option<Bytes>>>,
-        param_types: Option<Vec<Type>>,
-        do_describe: bool,
-        connection_id: u64,
-    ) -> datafusion::error::Result<(Vec<HashMap<String, String>>, Vec<Vec<Option<String>>>)> {
-        let ctx = self.catalog_ctx.clone();
-        let py_worker = self.py_worker.clone();
-        let handler = move |_ctx: &SessionContext, sql: &str, p, t| {
-            let py_worker = py_worker.clone();
-            let sql_owned = sql.to_string();
-            async move {
-                let (schema_desc, rows) = py_worker
-                    .on_query(sql_owned, p, t, do_describe, connection_id)
-                    .await;
-                let (batches, schema) = rows_to_record_batch(&schema_desc, &rows);
-                Ok((batches, schema))
-            }
-        };
-
-        let (batches, schema) = dispatch_query(&ctx, &query, params, param_types, handler).await?;
-        Ok(record_batches_to_rows(batches, schema))
-    }
-}
-
-#[async_trait]
-impl QueryRunnerArrow for RouterQueryRunner {
-    async fn execute_arrow(
         &self,
         query: String,
         params: Option<Vec<Option<Bytes>>>,
@@ -776,8 +739,7 @@ impl QueryRunnerArrow for RouterQueryRunner {
                 let (schema_desc, rows) = py_worker
                     .on_query(sql_owned, p, t, do_describe, connection_id)
                     .await;
-                let (batches, schema) = rows_to_record_batch(&schema_desc, &rows);
-                Ok((batches, schema))
+                Ok(rows_to_arrow_batches(&schema_desc, &rows))
             }
         };
 
@@ -798,37 +760,19 @@ impl QueryRunner for DirectQueryRunner {
         param_types: Option<Vec<Type>>,
         do_describe: bool,
         connection_id: u64,
-    ) -> datafusion::error::Result<(Vec<HashMap<String, String>>, Vec<Vec<Option<String>>>)> {
-        let (desc, rows) = self
-            .py_worker
-            .on_query(query, params, param_types, do_describe, connection_id)
-            .await;
-        Ok((desc, rows))
-    }
-}
-
-#[async_trait]
-impl QueryRunnerArrow for DirectQueryRunner {
-    async fn execute_arrow(
-        &self,
-        query: String,
-        params: Option<Vec<Option<Bytes>>>,
-        param_types: Option<Vec<Type>>,
-        do_describe: bool,
-        connection_id: u64,
     ) -> datafusion::error::Result<ArrowQueryResult> {
         let (desc, rows) = self
             .py_worker
             .on_query(query, params, param_types, do_describe, connection_id)
             .await;
-        Ok(rows_to_record_batch(&desc, &rows))
+        Ok(rows_to_arrow_batches(&desc, &rows))
     }
 }
 
 pub struct RiffqProcessor {
     py_worker: Arc<PythonWorker>,
     conn_id_sender: Arc<Mutex<Option<oneshot::Sender<u64>>>>,
-    query_runner: Arc<dyn QueryRunnerCombined>,
+    query_runner: Arc<dyn QueryRunner>,
 }
 
 
@@ -967,74 +911,13 @@ impl SimpleQueryHandler for RiffqProcessor {
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(0);
 
-        #[cfg(feature = "zero_copy")]
         let (schema, data_row_stream) = {
             let (batches, schema) = self
-                .query_runner
-                .execute_arrow(query.to_string(), None, None, false, connection_id)
-                .await
-                .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
-            arrow_to_pg_rows(batches, schema)
-        };
-
-        #[cfg(not(feature = "zero_copy"))]
-        let (schema, data_row_stream) = {
-            let (schema_desc, rows_list) = self
                 .query_runner
                 .execute(query.to_string(), None, None, false, connection_id)
                 .await
                 .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
-            debug!("[PGWIRE] Schema and rows received");
-
-            // adjust column types based on values when type is reported as str
-            let mut adjusted_desc = schema_desc.clone();
-            for (idx, col) in adjusted_desc.iter_mut().enumerate() {
-                if col.get("type").map(|t| t.as_str()) == Some("str") {
-                    for row in &rows_list {
-                        if let Some(Some(val)) = row.get(idx) {
-                            if val.parse::<i64>().is_ok() {
-                                col.insert("type".to_string(), "int".to_string());
-                                break;
-                            } else if val.parse::<f64>().is_ok() {
-                                col.insert("type".to_string(), "float".to_string());
-                                break;
-                            } else if val.eq_ignore_ascii_case("true") || val.eq_ignore_ascii_case("false") {
-                                col.insert("type".to_string(), "bool".to_string());
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            let mut fields = Vec::new();
-            for col in &adjusted_desc {
-                let col_name = col.get("name").unwrap();
-                let col_type = col.get("type").unwrap();
-
-                fields.push(FieldInfo::new(
-                    col_name.clone().into(),
-                    None,
-                    None,
-                    map_python_type_to_pgwire(col_type),
-                    FieldFormat::Text,
-                ));
-            }
-
-            let schema_arc = Arc::new(fields);
-            let schema_ref = schema_arc.clone();
-            let desc_clone = adjusted_desc.clone();
-
-            let data_row_stream = futures::stream::iter(rows_list.into_iter()).map(move |row| {
-                let schema_desc = desc_clone.clone();
-                let mut encoder = DataRowEncoder::new(schema_ref.clone());
-                for (idx, val) in row.iter().enumerate() {
-                    let col_type = schema_desc[idx].get("type").unwrap();
-                    encode_value(&mut encoder, val, col_type)?;
-                }
-                encoder.finish()
-            });
-            (schema_arc, data_row_stream)
+            arrow_to_pg_rows(batches, schema)
         };
 
         Ok(vec![Response::Query(QueryResponse::new(schema, data_row_stream))])
@@ -1042,7 +925,7 @@ impl SimpleQueryHandler for RiffqProcessor {
 }
 
 pub struct MyExtendedQueryHandler {
-    query_runner: Arc<dyn QueryRunnerCombined>,
+    query_runner: Arc<dyn QueryRunner>,
 }
 #[derive(Clone)]
 pub struct MyStatement {
@@ -1117,25 +1000,8 @@ impl ExtendedQueryHandler for MyExtendedQueryHandler {
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(0);
 
-        #[cfg(feature = "zero_copy")]
         let (schema, data_row_stream) = {
             let (batches, schema) = self
-                .query_runner
-                .execute_arrow(
-                    query.to_string(),
-                    Some(portal.parameters.clone()),
-                    Some(portal.statement.parameter_types.clone()),
-                    false,
-                    connection_id,
-                )
-                .await
-                .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
-            arrow_to_pg_rows(batches, schema)
-        };
-
-        #[cfg(not(feature = "zero_copy"))]
-        let (schema, data_row_stream) = {
-            let (schema_desc, rows_list) = self
                 .query_runner
                 .execute(
                     query.to_string(),
@@ -1146,54 +1012,7 @@ impl ExtendedQueryHandler for MyExtendedQueryHandler {
                 )
                 .await
                 .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
-
-            let mut adjusted_desc = schema_desc.clone();
-            for (idx, col) in adjusted_desc.iter_mut().enumerate() {
-                if col.get("type").map(|t| t.as_str()) == Some("str") {
-                    for row in &rows_list {
-                        if let Some(Some(val)) = row.get(idx) {
-                            if val.parse::<i64>().is_ok() {
-                                col.insert("type".to_string(), "int".to_string());
-                                break;
-                            } else if val.parse::<f64>().is_ok() {
-                                col.insert("type".to_string(), "float".to_string());
-                                break;
-                            } else if val.eq_ignore_ascii_case("true") || val.eq_ignore_ascii_case("false") {
-                                col.insert("type".to_string(), "bool".to_string());
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            let mut fields = Vec::new();
-            for col in &adjusted_desc {
-                let col_name = col.get("name").unwrap();
-                let col_type = col.get("type").unwrap();
-                fields.push(FieldInfo::new(
-                    col_name.clone().into(),
-                    None,
-                    None,
-                    map_python_type_to_pgwire(col_type),
-                    FieldFormat::Text,
-                ));
-            }
-
-            let schema_arc = Arc::new(fields);
-            let schema_ref = schema_arc.clone();
-            let desc_clone = adjusted_desc.clone();
-
-            let stream = futures::stream::iter(rows_list.into_iter()).map(move |row| {
-                let schema_desc = desc_clone.clone();
-                let mut encoder = DataRowEncoder::new(schema_ref.clone());
-                for (idx, val) in row.iter().enumerate() {
-                    let col_type = schema_desc[idx].get("type").unwrap();
-                    encode_value(&mut encoder, val, col_type)?;
-                }
-                encoder.finish()
-            });
-            (schema_arc, stream)
+            arrow_to_pg_rows(batches, schema)
         };
 
         Ok(Response::Query(QueryResponse::new(schema, data_row_stream)))
@@ -1232,11 +1051,10 @@ impl ExtendedQueryHandler for MyExtendedQueryHandler {
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(0);
 
-        #[cfg(feature = "zero_copy")]
         {
             let (batches, schema) = self
                 .query_runner
-                .execute_arrow(
+                .execute(
                     query.to_string(),
                     Some(portal.parameters.clone()),
                     Some(portal.statement.parameter_types.clone()),
@@ -1258,55 +1076,6 @@ impl ExtendedQueryHandler for MyExtendedQueryHandler {
                     )
                 })
                 .collect();
-            Ok(DescribePortalResponse::new(fields))
-        }
-
-        #[cfg(not(feature = "zero_copy"))]
-        {
-            let (schema_desc, rows_list) = self
-                .query_runner
-                .execute(
-                    query.to_string(),
-                    Some(portal.parameters.clone()),
-                    Some(portal.statement.parameter_types.clone()),
-                    true,
-                    connection_id,
-                )
-                .await
-                .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
-            let mut adjusted_desc = schema_desc.clone();
-            for (idx, col) in adjusted_desc.iter_mut().enumerate() {
-                if col.get("type").map(|t| t.as_str()) == Some("str") {
-                    for row in &rows_list {
-                        if let Some(Some(val)) = row.get(idx) {
-                            if val.parse::<i64>().is_ok() {
-                                col.insert("type".to_string(), "int".to_string());
-                                break;
-                            } else if val.parse::<f64>().is_ok() {
-                                col.insert("type".to_string(), "float".to_string());
-                                break;
-                            } else if val.eq_ignore_ascii_case("true") || val.eq_ignore_ascii_case("false") {
-                                col.insert("type".to_string(), "bool".to_string());
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            let mut fields = Vec::new();
-            for col in &adjusted_desc {
-                let col_name = col.get("name").unwrap();
-                let col_type = col.get("type").unwrap();
-                fields.push(FieldInfo::new(
-                    col_name.clone().into(),
-                    None,
-                    None,
-                    map_python_type_to_pgwire(col_type),
-                    FieldFormat::Text,
-                ));
-            }
-
             Ok(DescribePortalResponse::new(fields))
         }
     }
@@ -1465,7 +1234,7 @@ impl Server {
             let py_worker = Arc::new(PythonWorker::new(query_cb, connect_cb, disconnect_cb, auth_cb));
             let (ctx, _) = get_base_session_context(None, "datafusion".to_string(), "public".to_string()).await.unwrap();
             let catalog_ctx = Arc::new(ctx);
-            let query_runner: Arc<dyn QueryRunnerCombined> = if catalog_emulation {
+            let query_runner: Arc<dyn QueryRunner> = if catalog_emulation {
                 Arc::new(RouterQueryRunner { py_worker: py_worker.clone(), catalog_ctx: catalog_ctx.clone() })
             } else {
                 Arc::new(DirectQueryRunner { py_worker: py_worker.clone() })


### PR DESCRIPTION
## Summary
- remove `zero_copy` feature and old string-based query logic
- unify query runner traits to always return Arrow batches
- delete obsolete stringification helpers
- stream rows directly from Arrow batches

## Testing
- `cargo check`
- `cargo test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505a45addc832f87bef347fb3eb68b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the zero_copy feature and unified all query execution to use Arrow batches, simplifying the code and improving consistency.

- **Refactors**
  - Deleted old string-based query logic and helpers.
  - Updated query runner traits to always return Arrow batches.
  - Streamlined row handling to work directly with Arrow data.

<!-- End of auto-generated description by cubic. -->

