### PR TITLE
Implement arrow-only query runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,4 @@ env_logger = "0.11.8"
 
 [features]
 default = []
-zero_copy = []
 

--- a/agent-tasks/104.md
+++ b/agent-tasks/104.md
@@ -23,4 +23,4 @@ map_python_type_to_pgwire.
 • Delete the “adjusted_desc” re-typing loops; Field::data_type is now the single source of truth.
 • Make sure all remaining code that builds FieldInfo uses arrow_type_to_pgwire.
 • Search the codebase for "_to_string" or adjusted_desc to confirm nothing lingers.
-• cargo check again; repository must compile and unit tests must pass.
+• cargo check again; repository must compile and unit tests must pass.\nNotes: Subtask 3 is not fully implemented due to complexity in adjusting Python worker and callback to return Arrow results without the removed helpers. Attempted partial refactor but functions are still used. Further work needed to refactor CallbackWrapper and related code.


### PR DESCRIPTION
## Summary
- remove zero_copy feature and conditional logic
- update query execution to return arrow batches
- adapt query runner implementations
- document incomplete subtask 3 work

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68505a45addc832f87bef347fb3eb68b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the zero_copy feature and updated the query runner to always return Arrow batches, simplifying query execution and related code.

- **Refactors**
  - Deleted all zero_copy conditional logic and related code paths.
  - Updated query runner interfaces and implementations to use Arrow-only results.
  - Added a note in the task file about incomplete subtask 3 work.

<!-- End of auto-generated description by cubic. -->

