### PR TITLE
Add build-release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,43 @@
+name: build-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.4.0)'
+        required: true
+      prerelease:
+        description: 'Mark as pre-release'
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: PyO3/maturin-action@v1
+      with:
+        command: build
+        args: --release
+    - uses: actions/upload-artifact@v4
+      with:
+        name: wheels
+        path: target/wheels/*.whl
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: wheels
+    - uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ github.event.inputs.tag }}
+        prerelease: ${{ github.event.inputs.prerelease }}
+        files: |
+          *.whl


### PR DESCRIPTION
## Summary
- add a build-release workflow for building release wheels on multiple OSes and creating GitHub releases

## Testing
- `python -m unittest discover -s tests`
- `python -m unittest discover -s test_concurrency`


------
https://chatgpt.com/codex/tasks/task_e_68515bd5091c832fa5590fbc90a3aafd
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a build-release workflow to automate building release wheels on Linux, Windows, and macOS, and to create GitHub releases with those wheels.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a new workflow for building and releasing project artifacts across multiple operating systems, with manual trigger support and automated attachment of build files to GitHub releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->