### PR TITLE
Add server registration API

### DIFF
--- a/tests/test_register_user_catalog.py
+++ b/tests/test_register_user_catalog.py
@@ -1,0 +1,69 @@
+import multiprocessing
+import socket
+import time
+import unittest
+import psycopg
+from helpers import _ensure_riffq_built
+
+
+def _run_server(port: int):
+    import riffq
+    from riffq.helpers import to_arrow
+
+    def handle_query(sql, callback, **kwargs):
+        callback(to_arrow([{"name": "val", "type": "int"}], [[1]]))
+
+    server = riffq.Server(f"127.0.0.1:{port}")
+    server.on_query(handle_query)
+    server.register_database("crm")
+    server.register_table("users", [("id", "int", False), ("name", "text", True)])
+    server.start(catalog_emulation=True)
+
+
+class RegisterCatalogTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_riffq_built()
+        cls.port = 55450
+        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port,), daemon=True)
+        cls.proc.start()
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            cls.proc.terminate()
+            cls.proc.join()
+            raise RuntimeError("Server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+
+    def test_registered_database(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        with conn.cursor() as cur:
+            cur.execute("SELECT datname FROM pg_catalog.pg_database WHERE datname='pgtry'")
+            self.assertEqual(cur.fetchone()[0], "pgtry")
+        conn.close()
+
+    def test_registered_table(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        with conn.cursor() as cur:
+            cur.execute("SELECT relname FROM pg_catalog.pg_class WHERE relname='users'")
+            self.assertEqual(cur.fetchone()[0], "users")
+            cur.execute(
+                "SELECT attname FROM pg_catalog.pg_attribute "
+                "WHERE attrelid = (SELECT oid FROM pg_catalog.pg_class WHERE relname='users') "
+                "ORDER BY attnum"
+            )
+            rows = [r[0] for r in cur.fetchall()]
+            self.assertEqual(rows, ["id", "name"])
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose APIs on the server for registering custom databases and tables
- register the custom items when the server starts
- test registering tables/databases through the server

## Testing
- `maturin build --profile=fast -i python3`
- `pip install --force-reinstall target/wheels/*.whl`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685191cdcf14832f92d8c037c520b49c
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added server APIs to register custom databases and tables, and ensured they are available when the server starts.

- **New Features**
  - Added register_database and register_table methods to the server.
  - Registered user-defined databases and tables during server startup.
  - Added tests to verify registration and visibility of custom databases and tables.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for registering user-defined databases and tables, allowing custom schemas to be integrated and queried.
- **Tests**
  - Introduced new tests to verify that registered databases and tables are correctly exposed and accessible via SQL queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->