### PR TITLE
Add dynamic catalog registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "datafusion_pg_catalog"
 version = "0.1.0"
-source = "git+https://github.com/ybrs/pg_catalog?branch=main#2952ad2cd9fdcbee5d36dba950178d10fead7281"
+source = "git+https://github.com/ybrs/pg_catalog?branch=main#e64f18b76123049e042ac43336e37d8c8b12c6dd"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ arrow = { version = "55.1.0", features = ["ffi", "canonical_extension_types"] }
 chrono = "0.4.41"
 log = "0.4"
 datafusion = "47.0.0"
-datafusion_pg_catalog = { git = "https://github.com/ybrs/pg_catalog", branch = "main", package = "datafusion_pg_catalog" }
+pg_catalog_rs = { git = "https://github.com/ybrs/pg_catalog", branch = "main", package = "datafusion_pg_catalog" }
 env_logger = "0.11.8"
 
 

--- a/tests/test_register_catalog.py
+++ b/tests/test_register_catalog.py
@@ -1,0 +1,78 @@
+import multiprocessing
+import socket
+import time
+import unittest
+import psycopg
+from helpers import _ensure_riffq_built
+
+
+def _run_server(port: int):
+    import riffq
+    import pyarrow as pa
+
+    def send_batch(batch: pa.RecordBatch, callback):
+        rdr = pa.RecordBatchReader.from_batches(batch.schema, [batch])
+        if hasattr(rdr, "__arrow_c_stream__"):
+            capsule = rdr.__arrow_c_stream__()
+        else:
+            from pyarrow.cffi import export_stream
+            capsule = export_stream(rdr)
+        callback(capsule)
+
+    def handle_query(sql, callback, **kwargs):
+        batch = pa.record_batch([pa.array([1], pa.int64())], names=["val"])
+        send_batch(batch, callback)
+
+    server = riffq.Server(f"127.0.0.1:{port}")
+    server.register_database("crm")
+    server.register_schema("crm", "public")
+    server.register_table(
+        "crm",
+        "public",
+        "users",
+        [{"id": {"type": "int", "nullable": False}}],
+    )
+    server.on_query(handle_query)
+    server.start(catalog_emulation=True)
+
+
+class RegisterCatalogTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_riffq_built()
+        cls.port = 55450
+        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port,), daemon=True)
+        cls.proc.start()
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            cls.proc.terminate()
+            cls.proc.join()
+            raise RuntimeError("Server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+
+    def test_registered_database(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        with conn.cursor() as cur:
+            cur.execute("SELECT datname FROM pg_catalog.pg_database WHERE datname='crm'")
+            self.assertEqual(cur.fetchone()[0], "crm")
+        conn.close()
+
+    def test_registered_table(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        with conn.cursor() as cur:
+            cur.execute("SELECT relname FROM pg_catalog.pg_class WHERE relname='users'")
+            self.assertEqual(cur.fetchone()[0], "users")
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update dependency alias to `pg_catalog_rs`
- expose registration queues in `Server`
- add Python methods to register databases, schemas and tables
- apply registrations on server start
- test registering custom catalog data

## Testing
- `cargo test --quiet`
- `pytest -q tests/test_register_catalog.py::RegisterCatalogTest::test_registered_database -vv` *(fails: ModuleNotFoundError: No module named 'riffq')*

------
https://chatgpt.com/codex/tasks/task_e_6851c3f7bdb8832f92c389df0e7682be
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for dynamic registration of databases, schemas, and tables from Python, allowing custom catalog data to be set before server start.

- **New Features**
  - Added Python methods to register databases, schemas, and tables.
  - Registrations are applied automatically when the server starts.
  - Added tests to verify custom catalog registration.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for registering user-defined databases, schemas, and tables, including column definitions, allowing for custom catalog emulation.
- **Tests**
  - Introduced integration tests to verify that registered databases and tables appear correctly in the catalog using standard PostgreSQL queries.
- **Chores**
  - Updated a dependency name in the configuration for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->