### PR TITLE
Add catalog registration APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,7 @@ __pycache__/
 venv/
 duckdata.*
 example/data/*
-+riffq/_riffq*.so
+riffq/_riffq*.so
+
+.venv/
+pysrc/riffq/_riffq*.so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "datafusion_pg_catalog"
 version = "0.1.0"
-source = "git+https://github.com/ybrs/pg_catalog?branch=main#2952ad2cd9fdcbee5d36dba950178d10fead7281"
+source = "git+https://github.com/ybrs/pg_catalog?branch=main#e64f18b76123049e042ac43336e37d8c8b12c6dd"
 dependencies = [
  "anyhow",
  "arrow",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use tokio::signal;
 use tokio::sync::oneshot;
 use tokio::io::{AsyncWriteExt, AsyncReadExt};
 use tokio::net::TcpStream;
-use pyo3::types::{PyDict, PyList, PyTuple, PyCapsule};
+use pyo3::types::{PyDict, PyList, PyTuple, PyCapsule, PyDictMethods};
 use std::fs::File;
 use std::io::{BufReader, Error as IOError, ErrorKind};
 use rustls_pemfile::{certs, pkcs8_private_keys};
@@ -17,7 +17,7 @@ use tokio_rustls::rustls::ServerConfig;
 use tokio_rustls::TlsAcceptor;
 use log::{debug, error, info};
 
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeMap};
 use std::sync::mpsc::{channel, Sender};
 use std::thread;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -34,7 +34,14 @@ use arrow::record_batch::RecordBatchReader;
 use arrow::datatypes::{DataType, Field, Schema, TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType};
 use arrow::array::{ArrayRef, StringBuilder};
 use datafusion::execution::context::SessionContext;
-use datafusion_pg_catalog::{dispatch_query, get_base_session_context};
+use datafusion_pg_catalog::{
+    dispatch_query,
+    get_base_session_context,
+    register_user_database,
+    register_schema,
+    register_user_tables,
+    ColumnDef,
+};
 use postgres_types::FromSql;
 
 use chrono::{DateTime, Duration, NaiveDate};
@@ -97,6 +104,14 @@ struct CallbackWrapper {
 #[pyclass]
 struct BoolCallbackWrapper {
     responder: Arc<Mutex<Option<oneshot::Sender<bool>>>>,
+}
+
+#[derive(Clone)]
+struct TableRegistration {
+    database: String,
+    schema: String,
+    table: String,
+    columns: Vec<BTreeMap<String, ColumnDef>>,
 }
 
 #[pymethods]
@@ -1043,6 +1058,9 @@ pub struct Server {
     on_disconnect_cb: Arc<Mutex<Option<Py<PyAny>>>>,
     on_authentication_cb: Arc<Mutex<Option<Py<PyAny>>>>,
     tls_acceptor: Arc<Mutex<Option<Arc<TlsAcceptor>>>>,
+    databases: Arc<Mutex<Vec<String>>>,
+    schemas: Arc<Mutex<Vec<(String, String)>>>,
+    tables: Arc<Mutex<Vec<TableRegistration>>>,
 }
 
 #[pymethods]
@@ -1056,6 +1074,9 @@ impl Server {
             on_disconnect_cb: Arc::new(Mutex::new(None)),
             on_authentication_cb: Arc::new(Mutex::new(None)),
             tls_acceptor: Arc::new(Mutex::new(None)),
+            databases: Arc::new(Mutex::new(Vec::new())),
+            schemas: Arc::new(Mutex::new(Vec::new())),
+            tables: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -1085,6 +1106,40 @@ impl Server {
         }
     }
 
+    fn register_database(&mut self, _py: Python, database: String) {
+        self.databases.lock().unwrap().push(database);
+    }
+
+    fn register_schema(&mut self, _py: Python, database: String, schema: String) {
+        self.schemas.lock().unwrap().push((database, schema));
+    }
+
+    fn register_table<'py>(
+        &mut self,
+        _py: Python<'py>,
+        database: String,
+        schema: String,
+        table: String,
+        columns: &Bound<'py, PyDict>,
+    ) -> PyResult<()> {
+        let mut cols = Vec::new();
+        for (name, def) in columns.iter() {
+            let col_name: String = name.extract()?;
+            let (col_type, nullable): (String, bool) = def.extract()?;
+            let mut map = BTreeMap::new();
+            map.insert(col_name, ColumnDef { col_type, nullable });
+            cols.push(map);
+        }
+        let reg = TableRegistration {
+            database,
+            schema,
+            table,
+            columns: cols,
+        };
+        self.tables.lock().unwrap().push(reg);
+        Ok(())
+    }
+
 
     #[pyo3(signature = (tls=false, catalog_emulation=false))]
     fn start(&self, py: Python, tls: bool, catalog_emulation: bool) {
@@ -1099,6 +1154,9 @@ impl Server {
         let connect_cb = self.on_connect_cb.clone();
         let disconnect_cb = self.on_disconnect_cb.clone();
         let auth_cb = self.on_authentication_cb.clone();
+        let reg_dbs = self.databases.clone();
+        let reg_schemas = self.schemas.clone();
+        let reg_tables = self.tables.clone();
 
         if query_cb.lock().unwrap().is_none() {
             panic!("No callback set. Use on_query() before starting the server.");
@@ -1113,6 +1171,24 @@ impl Server {
             let py_worker = Arc::new(PythonWorker::new(query_cb, connect_cb, disconnect_cb, auth_cb));
             let (ctx, _) = get_base_session_context(None, "datafusion".to_string(), "public".to_string()).await.unwrap();
             let catalog_ctx = Arc::new(ctx);
+
+            for db in reg_dbs.lock().unwrap().clone() {
+                register_user_database(&catalog_ctx, &db).await.unwrap();
+            }
+            for (db, sch) in reg_schemas.lock().unwrap().clone() {
+                register_schema(&catalog_ctx, &db, &sch).await.unwrap();
+            }
+            for tbl in reg_tables.lock().unwrap().clone() {
+                register_user_tables(
+                    &catalog_ctx,
+                    &tbl.database,
+                    &tbl.schema,
+                    &tbl.table,
+                    tbl.columns,
+                )
+                .await
+                .unwrap();
+            }
             let query_runner: Arc<dyn QueryRunner> = if catalog_emulation {
                 Arc::new(RouterQueryRunner { py_worker: py_worker.clone(), catalog_ctx: catalog_ctx.clone() })
             } else {

--- a/tests/test_register_catalog.py
+++ b/tests/test_register_catalog.py
@@ -1,0 +1,100 @@
+import multiprocessing
+import socket
+import time
+import unittest
+import psycopg
+from helpers import _ensure_riffq_built
+
+import pyarrow as pa
+
+
+def _run_server_register(port: int):
+    import riffq
+    import pyarrow as pa
+
+    def send_batch(batch: pa.RecordBatch, callback):
+        rdr = pa.RecordBatchReader.from_batches(batch.schema, [batch])
+        if hasattr(rdr, "__arrow_c_stream__"):
+            capsule = rdr.__arrow_c_stream__()
+        else:
+            from pyarrow.cffi import export_stream  # type: ignore
+            capsule = export_stream(rdr)
+        callback(capsule)
+
+    def handle_query(sql, callback, **kwargs):
+        args = kwargs.get("query_args")
+        sql_clean = sql.strip().lower()
+        if sql_clean == "select multi":
+            batch = pa.record_batch(
+                [
+                    pa.array([1], pa.int64()),
+                    pa.array(["foo"], pa.string()),
+                    pa.array([3.14], pa.float64()),
+                    pa.array([None], pa.int64()),
+                ],
+                names=["a", "b", "c", "d"],
+            )
+            return send_batch(batch, callback)
+
+        if sql_clean == "select bool":
+            batch = pa.record_batch([pa.array([True], pa.bool_())], names=["flag"])
+            return send_batch(batch, callback)
+
+        if args:
+            value = int(args[0])
+        else:
+            if sql_clean.startswith("select ") and sql_clean[7:].isdigit():
+                value = int(sql_clean[7:])
+            else:
+                value = 1
+
+        batch = pa.record_batch([pa.array([value], pa.int64())], names=["val"])
+        send_batch(batch, callback)
+
+    server = riffq.Server(f"127.0.0.1:{port}")
+    server.register_database("crm")
+    server.register_schema("crm", "public")
+    server.register_table("crm", "public", "users", {"id": ("int", False)})
+    server.on_query(handle_query)
+    server.start(catalog_emulation=True)
+
+
+class RegisterCatalogTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_riffq_built()
+        cls.port = 55450
+        cls.proc = multiprocessing.Process(target=_run_server_register, args=(cls.port,), daemon=True)
+        cls.proc.start()
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            cls.proc.terminate()
+            cls.proc.join()
+            raise RuntimeError("Server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+
+    def test_registered_metadata(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        with conn.cursor() as cur:
+            cur.execute("SELECT datname FROM pg_catalog.pg_database WHERE datname='crm'")
+            self.assertEqual(cur.fetchone()[0], "crm")
+            cur.execute("SELECT relname FROM pg_catalog.pg_class WHERE relname='users'")
+            self.assertEqual(cur.fetchone()[0], "users")
+            cur.execute(
+                "SELECT attname FROM pg_catalog.pg_attribute WHERE attrelid = (SELECT oid FROM pg_catalog.pg_class WHERE relname='users')"
+            )
+            self.assertEqual(cur.fetchone()[0], "id")
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update `datafusion_pg_catalog` dependency
- support registering databases, schemas, and tables in `Server`
- include new Python test for registering catalog entries

## Testing
- `maturin develop --release`
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6851c3f7bdb8832f92c389df0e7682be