### PR TITLE
Add catalog registration features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "datafusion_pg_catalog"
 version = "0.1.0"
-source = "git+https://github.com/ybrs/pg_catalog?branch=main#2952ad2cd9fdcbee5d36dba950178d10fead7281"
+source = "git+https://github.com/ybrs/pg_catalog?branch=main#e64f18b76123049e042ac43336e37d8c8b12c6dd"
 dependencies = [
  "anyhow",
  "arrow",

--- a/tests/test_register_catalog.py
+++ b/tests/test_register_catalog.py
@@ -1,0 +1,66 @@
+import multiprocessing
+import socket
+import time
+import psycopg
+import unittest
+from helpers import _ensure_riffq_built
+import pyarrow as pa
+
+
+def _run_server(port: int):
+    import riffq
+    from riffq.helpers import to_arrow
+
+    def handle_query(sql, callback, **kwargs):
+        callback(to_arrow([{"name": "val", "type": "int"}], [[1]]))
+
+    server = riffq.Server(f"127.0.0.1:{port}")
+    server.register_database("mydb")
+    server.register_schema("mydb", "myschema")
+    server.register_table(
+        "mydb",
+        "myschema",
+        "users",
+        [{"id": {"type": "int", "nullable": False}}],
+    )
+    server.on_query(handle_query)
+    server.start(catalog_emulation=True)
+
+
+class RegisterCatalogTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_riffq_built()
+        cls.port = 55440
+        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port,), daemon=True)
+        cls.proc.start()
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            cls.proc.terminate()
+            cls.proc.join()
+            raise RuntimeError("Server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+
+    def test_registered_objects(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        with conn.cursor() as cur:
+            cur.execute("SELECT datname FROM pg_catalog.pg_database WHERE datname='mydb'")
+            self.assertEqual(cur.fetchone()[0], "mydb")
+            cur.execute("SELECT nspname FROM pg_catalog.pg_namespace WHERE nspname='myschema'")
+            self.assertEqual(cur.fetchone()[0], "myschema")
+            cur.execute("SELECT relname FROM pg_catalog.pg_class WHERE relname='users'")
+            self.assertEqual(cur.fetchone()[0], "users")
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update `datafusion_pg_catalog` dependency
- add registration API for databases, schemas and tables
- register catalog objects when starting the server
- test registering custom catalog objects

## Testing
- `cargo check`
- `pip install psycopg[binary]`
- `pip install -e .` *(fails: operation canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6851c3f7bdb8832f92c389df0e7682be
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added API methods to register databases, schemas, and tables, and updated the server to register these catalog objects at startup.

- **New Features**
  - Added register_database, register_schema, and register_table methods.
  - Catalog objects are now registered automatically when the server starts.
  - Added tests to verify custom catalog registration.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for registering user-defined databases, schemas, and tables, which are now reflected in the server's metadata and accessible via standard catalog queries.

- **Tests**
  - Introduced new automated tests to verify that registered databases, schemas, and tables appear correctly in the server's metadata when queried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->