### PR TITLE
Enable tags via Python callbacks

### DIFF
--- a/duckdb_pgcatalog/server.py
+++ b/duckdb_pgcatalog/server.py
@@ -48,7 +48,9 @@ def map_type(data_type: str) -> str:
 def run_server(port: int):
     global duckdb_con
     duckdb_con = duckdb.connect()
-    server = riffq.RiffqServer("127.0.0.1:5433", connection_cls=Connection)
+    server = riffq.Server(f"127.0.0.1:{port}")
+    conn_mgr = Connection(port)
+    server.on_query(conn_mgr.handle_query)
     # server.set_tls("certs/server.crt", "certs/server.key")
 
     # duckdb_con.execute("CREATE TABLE users(id INTEGER, name VARCHAR)")
@@ -63,7 +65,7 @@ def run_server(port: int):
     ).fetchall()
 
     for schema_name, table_name in tbls:
-        server.server.register_schema("duckdb", schema_name)
+        server.register_schema("duckdb", schema_name)
         cols_info = duckdb_con.execute(
             "SELECT column_name, data_type, is_nullable FROM information_schema.columns "
             "WHERE table_schema=? AND table_name=?",
@@ -79,7 +81,7 @@ def run_server(port: int):
                     }
                 }
             )
-        server.server.register_table("duckdb", schema_name, table_name, columns)
+        server.register_table("duckdb", schema_name, table_name, columns)
 
     server.start(catalog_emulation=True)
 

--- a/tests/test_duckdb_catalog.py
+++ b/tests/test_duckdb_catalog.py
@@ -38,7 +38,7 @@ class DuckDbCatalogTest(unittest.TestCase):
         cls.proc.join()
 
     def test_catalog_entries(self):
-        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        conn = psycopg.connect(f"postgresql://user:123@127.0.0.1:{self.port}/db")
         with conn.cursor() as cur:
             cur.execute("SELECT datname FROM pg_catalog.pg_database WHERE datname='duckdb'")
             self.assertEqual(cur.fetchone()[0], "duckdb")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,77 @@
+import multiprocessing
+import socket
+import time
+import psycopg
+import unittest
+from helpers import _ensure_riffq_built
+
+
+def _run_server(port: int):
+    import riffq
+    from riffq.helpers import to_arrow
+
+    def handle_query(sql, callback, *, tag_callback=None, **kwargs):
+        sql_clean = sql.strip().lower()
+        if sql_clean in ("begin", "commit", "rollback", "end"):
+            if tag_callback:
+                tag_callback("COMMIT" if sql_clean == "end" else sql_clean.upper())
+            return
+        if sql_clean.startswith("set "):
+            if tag_callback:
+                tag_callback("SET")
+            return
+        if sql_clean.startswith("show "):
+            var = sql_clean.split()[1]
+            callback(to_arrow([{"name": var, "type": "str"}], [["1"]]))
+            return
+        callback(([{"name": "val", "type": "int"}], [[1]]))
+
+    server = riffq.Server(f"127.0.0.1:{port}")
+    server.on_query(handle_query)
+    server.start()
+
+
+class TagTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_riffq_built()
+        cls.port = 55450
+        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port,), daemon=True)
+        cls.proc.start()
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            cls.proc.terminate()
+            cls.proc.join()
+            raise RuntimeError("Server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+
+    def test_transaction_tags(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        self.assertEqual(cur.statusmessage, "BEGIN")
+        cur.execute("COMMIT")
+        self.assertEqual(cur.statusmessage, "COMMIT")
+        conn.close()
+
+    def test_set_show(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        cur = conn.cursor()
+        cur.execute("SET myvar TO 1")
+        self.assertEqual(cur.statusmessage, "SET")
+        cur.execute("SHOW myvar")
+        self.assertEqual(cur.fetchone()[0], "1")
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow Python to return execution tags by adding a tag callback
- route BEGIN/COMMIT/ROLLBACK/END to Python handlers
- plumb tag info through query runners
- update DuckDB catalog server to respect passed port
- test tag callback functionality

## Testing
- `cargo check` *(fails: could not run due to environment restrictions)*
- `python -m unittest discover -s tests` *(fails: could not run due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68556b587674832fbed6accfa33e4abe
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for Python callbacks to return execution tags and routed transaction commands (BEGIN, COMMIT, ROLLBACK, END) to Python handlers.

- **New Features**
  - Enabled tag callbacks in Python to set status messages for queries.
  - Routed transaction commands to Python, allowing custom handling.
  - Updated DuckDB catalog server to use the specified port.
  - Added tests for tag callback and transaction tag behavior.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for returning a string tag alongside query results, allowing certain SQL commands (e.g., "BEGIN", "COMMIT", "SET") to return a status tag instead of a standard result.
  - Enabled dynamic server port configuration and automatic creation of default tables on startup.
- **Tests**
  - Introduced a new test suite to verify query tagging behavior, ensuring tags like "BEGIN", "COMMIT", and "SET" are correctly returned for relevant SQL commands.
  - Updated connection settings in existing tests to include authentication credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->