### PR TITLE
Fix concurrent query handling

### DIFF
--- a/test_concurrency/server.py
+++ b/test_concurrency/server.py
@@ -45,7 +45,17 @@ def get_schema_from_duckdb(columns, types):
 def _handle_query(sql, callback, **kwargs):
     local_con = duckdb_con.cursor()
     print("< received (python):", sql)
-    if sql.strip().lower() == "select pg_catalog.version()":
+    sql_clean = sql.strip().lower()
+
+    if sql_clean.startswith("begin"):
+        return callback("BEGIN", is_tag=True)
+    if sql_clean.startswith("commit"):
+        return callback("COMMIT", is_tag=True)
+    if sql_clean.startswith("rollback"):
+        return callback("ROLLBACK", is_tag=True)
+    if sql_clean.startswith("discard all"):
+        return callback("DISCARD ALL", is_tag=True)
+    if sql_clean == "select pg_catalog.version()":
         result = (
             [
                 {"name": "version", "type": "string"},
@@ -58,12 +68,12 @@ def _handle_query(sql, callback, **kwargs):
         return callback(result)
 
 
-    if sql.strip().lower() == "show transaction isolation level":
+    if sql_clean == "show transaction isolation level":
         return callback(([
             {"name": "transaction_isolation", "type": "string"},
         ], [ ["read committed"] ] ))
 
-    if sql.strip().lower() == "select current_schema()":
+    if sql_clean == "select current_schema()":
         return callback(([
                              {"name": "current_schema", "type": "string"},
                          ], [ ["public"] ] ))

--- a/test_concurrency/server_duckdb_arrow.py
+++ b/test_concurrency/server_duckdb_arrow.py
@@ -24,6 +24,15 @@ def _handle_query(sql, callback, **kwargs):
     cur = duckdb_con.cursor()
     text = sql.strip().lower().split(';')[0]
 
+    if text.startswith("begin"):
+        return callback("BEGIN", is_tag=True)
+    if text.startswith("commit"):
+        return callback("COMMIT", is_tag=True)
+    if text.startswith("rollback"):
+        return callback("ROLLBACK", is_tag=True)
+    if text.startswith("discard all"):
+        return callback("DISCARD ALL", is_tag=True)
+
     if text == "select pg_catalog.version()":
         batch = arrow_batch(
             [pa.array(["PostgreSQL 14.13"])],

--- a/test_concurrency/server_polars.py
+++ b/test_concurrency/server_polars.py
@@ -49,6 +49,15 @@ def _handle_query(sql, callback, **kwargs):
     print("< received (python):", sql)
     sql_lc = sql.strip().lower()
 
+    if sql_lc.startswith("begin"):
+        return callback("BEGIN", is_tag=True)
+    if sql_lc.startswith("commit"):
+        return callback("COMMIT", is_tag=True)
+    if sql_lc.startswith("rollback"):
+        return callback("ROLLBACK", is_tag=True)
+    if sql_lc.startswith("discard all"):
+        return callback("DISCARD ALL", is_tag=True)
+
     if sql_lc == "select pg_catalog.version()":
         return callback(([{"name": "version", "type": "string"}],
                          [["PostgreSQL 14.13"]]))


### PR DESCRIPTION
## Summary
- handle transaction tags in concurrency servers
- return tags instead of executing transaction SQL

## Testing
- `make all-tests`

------
https://chatgpt.com/codex/tasks/task_e_685850eba18c832f986f54bfb050f2f6