### PR TITLE
Fix concurrency server tag handling

### DIFF
--- a/test_concurrency/server.py
+++ b/test_concurrency/server.py
@@ -45,6 +45,22 @@ def get_schema_from_duckdb(columns, types):
 def _handle_query(sql, callback, **kwargs):
     local_con = duckdb_con.cursor()
     print("< received (python):", sql)
+    sql_lc = sql.strip().lower()
+
+    if sql_lc.startswith("set"):
+        return callback("SET", is_tag=True)
+
+    if sql_lc.startswith("begin"):
+        return callback("BEGIN", is_tag=True)
+
+    if sql_lc.startswith("commit"):
+        return callback("COMMIT", is_tag=True)
+
+    if sql_lc.startswith("rollback"):
+        return callback("ROLLBACK", is_tag=True)
+
+    if sql_lc.startswith("discard all"):
+        return callback("DISCARD ALL", is_tag=True)
     if sql.strip().lower() == "select pg_catalog.version()":
         result = (
             [
@@ -59,6 +75,11 @@ def _handle_query(sql, callback, **kwargs):
 
 
     if sql.strip().lower() == "show transaction isolation level":
+        return callback(([
+            {"name": "transaction_isolation", "type": "string"},
+        ], [ ["read committed"] ] ))
+
+    if sql.strip().lower() == "show standard_conforming_strings":
         return callback(([
             {"name": "transaction_isolation", "type": "string"},
         ], [ ["read committed"] ] ))

--- a/test_concurrency/server_duckdb_arrow.py
+++ b/test_concurrency/server_duckdb_arrow.py
@@ -23,6 +23,20 @@ def arrow_batch(values, names):
 def _handle_query(sql, callback, **kwargs):
     cur = duckdb_con.cursor()
     text = sql.strip().lower().split(';')[0]
+    if text.startswith("set"):
+        return callback("SET", is_tag=True)
+
+    if text.startswith("begin"):
+        return callback("BEGIN", is_tag=True)
+
+    if text.startswith("commit"):
+        return callback("COMMIT", is_tag=True)
+
+    if text.startswith("rollback"):
+        return callback("ROLLBACK", is_tag=True)
+
+    if text.startswith("discard all"):
+        return callback("DISCARD ALL", is_tag=True)
 
     if text == "select pg_catalog.version()":
         batch = arrow_batch(

--- a/test_concurrency/server_polars.py
+++ b/test_concurrency/server_polars.py
@@ -49,11 +49,30 @@ def _handle_query(sql, callback, **kwargs):
     print("< received (python):", sql)
     sql_lc = sql.strip().lower()
 
+    if sql_lc.startswith("set"):
+        return callback("SET", is_tag=True)
+
+    if sql_lc.startswith("begin"):
+        return callback("BEGIN", is_tag=True)
+
+    if sql_lc.startswith("commit"):
+        return callback("COMMIT", is_tag=True)
+
+    if sql_lc.startswith("rollback"):
+        return callback("ROLLBACK", is_tag=True)
+
+    if sql_lc.startswith("discard all"):
+        return callback("DISCARD ALL", is_tag=True)
+
     if sql_lc == "select pg_catalog.version()":
         return callback(([{"name": "version", "type": "string"}],
                          [["PostgreSQL 14.13"]]))
 
     if sql_lc == "show transaction isolation level":
+        return callback(([{"name": "transaction_isolation", "type": "string"}],
+                         [["read committed"]]))
+
+    if sql_lc == "show standard_conforming_strings":
         return callback(([{"name": "transaction_isolation", "type": "string"}],
                          [["read committed"]]))
 


### PR DESCRIPTION
## Summary
- handle transaction tags in concurrency server implementations
- allow SHOW standard_conforming_strings query

## Testing
- `python -m unittest discover -s tests`
- `python -m unittest discover -s test_concurrency`

------
https://chatgpt.com/codex/tasks/task_e_685850eba18c832f986f54bfb050f2f6