### PR TITLE
Fix concurrency servers for transaction tag support

### DIFF
--- a/test_concurrency/server_duckdb_arrow.py
+++ b/test_concurrency/server_duckdb_arrow.py
@@ -24,6 +24,21 @@ def _handle_query(sql, callback, **kwargs):
     cur = duckdb_con.cursor()
     text = sql.strip().lower().split(';')[0]
 
+    if text.startswith("set"):
+        return callback("SET", is_tag=True)
+
+    if text.startswith("begin"):
+        return callback("BEGIN", is_tag=True)
+
+    if text.startswith("commit"):
+        return callback("COMMIT", is_tag=True)
+
+    if text.startswith("rollback"):
+        return callback("ROLLBACK", is_tag=True)
+
+    if text.startswith("discard all"):
+        return callback("DISCARD ALL", is_tag=True)
+
     if text == "select pg_catalog.version()":
         batch = arrow_batch(
             [pa.array(["PostgreSQL 14.13"])],
@@ -40,8 +55,8 @@ def _handle_query(sql, callback, **kwargs):
 
     if text == "show standard_conforming_strings":
         batch = arrow_batch(
-            [pa.array(["read committed"])],
-            ["transaction_isolation"],
+            [pa.array(["on"])],
+            ["standard_conforming_strings"],
         )
         return send_reader(batch, callback)
     

--- a/test_concurrency/server_polars.py
+++ b/test_concurrency/server_polars.py
@@ -49,6 +49,21 @@ def _handle_query(sql, callback, **kwargs):
     print("< received (python):", sql)
     sql_lc = sql.strip().lower()
 
+    if sql_lc.startswith("set"):
+        return callback("SET", is_tag=True)
+
+    if sql_lc.startswith("begin"):
+        return callback("BEGIN", is_tag=True)
+
+    if sql_lc.startswith("commit"):
+        return callback("COMMIT", is_tag=True)
+
+    if sql_lc.startswith("rollback"):
+        return callback("ROLLBACK", is_tag=True)
+
+    if sql_lc.startswith("discard all"):
+        return callback("DISCARD ALL", is_tag=True)
+
     if sql_lc == "select pg_catalog.version()":
         return callback(([{"name": "version", "type": "string"}],
                          [["PostgreSQL 14.13"]]))
@@ -56,6 +71,10 @@ def _handle_query(sql, callback, **kwargs):
     if sql_lc == "show transaction isolation level":
         return callback(([{"name": "transaction_isolation", "type": "string"}],
                          [["read committed"]]))
+
+    if sql_lc == "show standard_conforming_strings":
+        return callback(([{"name": "standard_conforming_strings", "type": "string"}],
+                         [["on"]]))
 
     if sql_lc == "select current_schema()":
         return callback(([{"name": "current_schema", "type": "string"}],


### PR DESCRIPTION
## Summary
- add transaction tag handling to test_concurrency servers
- support `SHOW standard_conforming_strings`
- fix arrow server response values

## Testing
- `make all-tests`

------
https://chatgpt.com/codex/tasks/task_e_685850eba18c832f986f54bfb050f2f6