### PR TITLE
Fix PyPI release version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "riffq"
-version = "0.1.0"
+dynamic = ["version"]
 requires-python = ">=3.8"
 classifiers = ["Programming Language :: Rust"]
 packages = [{ include = "riffq", from = "pysrc" }] 


### PR DESCRIPTION
## Summary
- set the Python package version to be read from Cargo.toml

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'riffq')*

------
https://chatgpt.com/codex/tasks/task_e_6859706fb298832fb0926d098ec3d910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project configuration to use a dynamically determined version instead of a fixed version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->