### PR TITLE
Add teleduck package and workflow tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,12 @@ jobs:
         run: pip install maturin
       - name: Install wheel
         run: pip install .
+      - name: Install teleduck
+        run: pip install ./teleduck
       - name: Run Python unit tests
         run: python -m unittest discover -s tests
       - name: Run concurrency unit tests
         run: python -m unittest discover -s test_concurrency
+      - name: Run teleduck unit tests
+        run: python -m unittest discover -s teleduck -p 'test_*.py'
 

--- a/teleduck/__main__.py
+++ b/teleduck/__main__.py
@@ -3,9 +3,10 @@ import click
 
 @click.command()
 @click.argument("db_file", type=click.Path())
+@click.option("--host", default="127.0.0.1", show_default=True, help="Host to listen on")
 @click.option("--port", default=5433, show_default=True, help="Port to listen on")
-def main(db_file: str, port: int):
-    run_server(db_file, port)
+def main(db_file: str, host: str, port: int):
+    run_server(db_file, port, host=host)
 
 if __name__ == "__main__":
     main()

--- a/teleduck/pyproject.toml
+++ b/teleduck/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "teleduck"
+version = "0.1.0"
+description = "Serve DuckDB over PostgreSQL protocol using riffq"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "duckdb",
+    "pyarrow",
+    "click",
+    "riffq",
+]
+
+[project.scripts]
+teleduck = "teleduck.__main__:main"

--- a/teleduck/server.py
+++ b/teleduck/server.py
@@ -85,19 +85,13 @@ class Connection(riffq.BaseConnection):
         # return callback(user == "user" and password == "secret")
         callback(True)
 
-def run_server(db_file: str, port: int = 5433):
+def run_server(db_file: str, port: int = 5433, host: str = "127.0.0.1"):
     """Start the teleduck server using the given DuckDB database file."""
 
     global duckdb_con
     duckdb_con = duckdb.connect(db_file)
 
-    duckdb_con.execute("CREATE TABLE IF NOT EXISTS users(id INTEGER, name VARCHAR)")
-    duckdb_con.execute("CREATE TABLE IF NOT EXISTS projects(id INTEGER, name VARCHAR)")
-    duckdb_con.execute(
-        "CREATE TABLE IF NOT EXISTS tasks(id INTEGER, project_id INTEGER, description VARCHAR)"
-    )
-
-    server = riffq.RiffqServer(f"127.0.0.1:{port}", connection_cls=Connection)
+    server = riffq.RiffqServer(f"{host}:{port}", connection_cls=Connection)
     cert_dir = Path(__file__).parent / "certs"
     server.set_tls(str(cert_dir / "server.crt"), str(cert_dir / "server.key"))
 

--- a/teleduck/test_cli.py
+++ b/teleduck/test_cli.py
@@ -1,0 +1,16 @@
+import unittest
+from unittest.mock import patch
+from click.testing import CliRunner
+
+from teleduck.__main__ import main
+
+class CliTest(unittest.TestCase):
+    def test_cli_invokes_run_server(self):
+        runner = CliRunner()
+        with patch('teleduck.__main__.run_server') as mock_run_server:
+            result = runner.invoke(main, ['my.db', '--host', '127.0.0.1', '--port', '9999'])
+            self.assertEqual(result.exit_code, 0)
+            mock_run_server.assert_called_once_with('my.db', 9999, host='127.0.0.1')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- package `teleduck` so it can be installed independently
- allow specifying host in `run_server` and CLI
- remove example table creation from server startup
- test CLI invocation
- run teleduck tests in CI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859c62b0dcc832fb59cd4f8807a3cb4