### PR TITLE
Add multi-database catalog contexts

### DIFF
--- a/tests/test_multiple_databases.py
+++ b/tests/test_multiple_databases.py
@@ -1,0 +1,77 @@
+import multiprocessing
+import socket
+import time
+import psycopg
+import unittest
+from helpers import _ensure_riffq_built
+
+
+def _run_server(port: int):
+    import riffq
+    from riffq.helpers import to_arrow
+
+    def handle_query(sql, callback, **kwargs):
+        callback(to_arrow([{"name": "val", "type": "int"}], [[1]]))
+
+    server = riffq.Server(f"127.0.0.1:{port}")
+    server.register_database("db1")
+    server.register_database("db2")
+    server.register_schema("db1", "s1")
+    server.register_schema("db2", "s2")
+    server.register_table(
+        "db1",
+        "s1",
+        "t1",
+        [{"id": {"type": "int", "nullable": False}}],
+    )
+    server.register_table(
+        "db2",
+        "s2",
+        "t2",
+        [{"id": {"type": "int", "nullable": False}}],
+    )
+    server.on_query(handle_query)
+    server.start(catalog_emulation=True)
+
+
+class MultipleDatabaseTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_riffq_built()
+        cls.port = 55441
+        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port,), daemon=True)
+        cls.proc.start()
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            cls.proc.terminate()
+            cls.proc.join()
+            raise RuntimeError("Server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+
+    def test_isolation(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db1")
+        with conn.cursor() as cur:
+            cur.execute("SELECT relname FROM pg_catalog.pg_class WHERE relname='t1'")
+            self.assertEqual(cur.fetchone()[0], "t1")
+            cur.execute("SELECT datname FROM pg_catalog.pg_database WHERE datname='db2'")
+            self.assertEqual(cur.fetchone()[0], "db2")
+        conn.close()
+
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db2")
+        with conn.cursor() as cur:
+            cur.execute("SELECT relname FROM pg_catalog.pg_class WHERE relname='t2'")
+            self.assertEqual(cur.fetchone()[0], "t2")
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- duplicate pg catalog session contexts per database
- switch connection context to selected database on startup
- keep query runner in sync with current context
- test registration works with multiple databases

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6859d4c17234832fae71d30c094773c7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for multiple databases with isolated schemas and tables, allowing dynamic switching between database contexts per client connection.
- **Bug Fixes**
	- Ensured thread-safe access and updates to session contexts, preventing conflicts during concurrent database operations.
- **Tests**
	- Introduced tests to verify proper isolation and visibility of tables and databases when connecting to different databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->