### PR TITLE
Add sql script options to teleduck CLI

### DIFF
--- a/teleduck/__main__.py
+++ b/teleduck/__main__.py
@@ -5,8 +5,27 @@ import click
 @click.argument("db_file", type=click.Path())
 @click.option("--host", default="127.0.0.1", show_default=True, help="Host to listen on")
 @click.option("--port", default=5433, show_default=True, help="Port to listen on")
-def main(db_file: str, host: str, port: int):
-    run_server(db_file, port, host=host)
+@click.option(
+    "--sql-script",
+    "sql_scripts",
+    multiple=True,
+    type=click.Path(),
+    help="SQL script file to run before starting the server",
+)
+@click.option(
+    "--sql",
+    "sqls",
+    multiple=True,
+    help="SQL statement to run before starting the server",
+)
+def main(
+    db_file: str,
+    host: str,
+    port: int,
+    sql_scripts: tuple[str, ...],
+    sqls: tuple[str, ...],
+):
+    run_server(db_file, port, host=host, sql_scripts=list(sql_scripts), sql=list(sqls))
 
 if __name__ == "__main__":
     main()

--- a/teleduck/test_cli.py
+++ b/teleduck/test_cli.py
@@ -10,7 +10,30 @@ class CliTest(unittest.TestCase):
         with patch('teleduck.__main__.run_server') as mock_run_server:
             result = runner.invoke(main, ['my.db', '--host', '127.0.0.1', '--port', '9999'])
             self.assertEqual(result.exit_code, 0)
-            mock_run_server.assert_called_once_with('my.db', 9999, host='127.0.0.1')
+            mock_run_server.assert_called_once_with(
+                'my.db', 9999, host='127.0.0.1', sql_scripts=[], sql=[]
+            )
+
+    def test_cli_sql_options(self):
+        runner = CliRunner()
+        with patch('teleduck.__main__.run_server') as mock_run_server:
+            result = runner.invoke(
+                main,
+                [
+                    'my.db',
+                    '--sql-script', 'init.sql',
+                    '--sql-script', 'data.sql',
+                    '--sql', 'INSERT INTO t VALUES (1)',
+                ],
+            )
+            self.assertEqual(result.exit_code, 0)
+            mock_run_server.assert_called_once_with(
+                'my.db',
+                5433,
+                host='127.0.0.1',
+                sql_scripts=['init.sql', 'data.sql'],
+                sql=['INSERT INTO t VALUES (1)'],
+            )
 
 if __name__ == '__main__':
     unittest.main()

--- a/teleduck/test_sql_init.py
+++ b/teleduck/test_sql_init.py
@@ -1,0 +1,69 @@
+import multiprocessing
+import socket
+import time
+import tempfile
+import os
+from pathlib import Path
+import psycopg
+import unittest
+
+
+def _run_server(db_file: str, port: int, scripts, sqls):
+    import sys
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from teleduck.server import run_server
+    run_server(db_file, port, sql_scripts=scripts, sql=sqls)
+
+
+class SqlInitTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.port = 55442
+        fd, cls.db_file = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        os.unlink(cls.db_file)
+
+        cls.script1 = tempfile.NamedTemporaryFile(delete=False, suffix=".sql")
+        cls.script1.write(b"CREATE TABLE t(v INTEGER);")
+        cls.script1.close()
+        cls.script2 = tempfile.NamedTemporaryFile(delete=False, suffix=".sql")
+        cls.script2.write(b"INSERT INTO t VALUES (1);")
+        cls.script2.close()
+
+        cls.proc = multiprocessing.Process(
+            target=_run_server,
+            args=(cls.db_file, cls.port, [cls.script1.name, cls.script2.name], ["INSERT INTO t VALUES (2);"]),
+            daemon=True,
+        )
+        cls.proc.start()
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            cls.proc.terminate()
+            cls.proc.join()
+            raise RuntimeError("Server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+        os.unlink(cls.db_file)
+        os.unlink(cls.script1.name)
+        os.unlink(cls.script2.name)
+
+    def test_scripts_executed(self):
+        conn = psycopg.connect(
+            f"postgresql://user:123@127.0.0.1:{self.port}/db"
+        )
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM t")
+            self.assertEqual(cur.fetchone()[0], 2)
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `teleduck` CLI with `--sql-script` and `--sql` options
- execute given SQL scripts and statements before starting the server
- update unit tests for CLI
- add integration test verifying SQL initialization

## Testing
- `python -m unittest discover -s teleduck`
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6859d7377004832f8b042a94bbcce157