### PR TITLE
Fix current_schemas UDF array handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,9 @@ use std::pin::Pin;
 use futures::stream::{self, BoxStream};
 
 use arrow::ffi_stream::ArrowArrayStreamReader;
-use arrow::array::{Array, RecordBatch};
+use arrow::array::{
+    Array, RecordBatch, ListArray, LargeListArray, FixedSizeListArray,
+};
 use arrow::array::cast::AsArray;
 use arrow::record_batch::RecordBatchReader;
 use arrow::datatypes::{DataType, Field, Schema, TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType};
@@ -302,6 +304,114 @@ fn arrow_to_pg_rows(
     (field_defs, Box::pin(row_stream))
 }
 
+fn arrow_value_to_string(array: &dyn Array, row: usize) -> Option<String> {
+    if array.is_null(row) {
+        return None;
+    }
+
+    match array.data_type() {
+        DataType::Int8 => Some(array.as_primitive::<arrow::array::types::Int8Type>().value(row).to_string()),
+        DataType::Int16 => Some(array.as_primitive::<arrow::array::types::Int16Type>().value(row).to_string()),
+        DataType::Int32 => Some(array.as_primitive::<arrow::array::types::Int32Type>().value(row).to_string()),
+        DataType::Int64 => Some(array.as_primitive::<arrow::array::types::Int64Type>().value(row).to_string()),
+        DataType::UInt8 => Some(array.as_primitive::<arrow::array::types::UInt8Type>().value(row).to_string()),
+        DataType::UInt16 => Some(array.as_primitive::<arrow::array::types::UInt16Type>().value(row).to_string()),
+        DataType::UInt32 => Some(array.as_primitive::<arrow::array::types::UInt32Type>().value(row).to_string()),
+        DataType::UInt64 => Some(array.as_primitive::<arrow::array::types::UInt64Type>().value(row).to_string()),
+        DataType::Float32 => Some(array.as_primitive::<arrow::array::types::Float32Type>().value(row).to_string()),
+        DataType::Float64 => Some(array.as_primitive::<arrow::array::types::Float64Type>().value(row).to_string()),
+        DataType::Boolean => Some(array.as_boolean().value(row).to_string()),
+        DataType::Utf8 => Some(array.as_string::<i32>().value(row).to_string()),
+        DataType::LargeUtf8 => Some(array.as_string::<i64>().value(row).to_string()),
+        DataType::Date32 => {
+            let days = array.as_primitive::<arrow::array::types::Date32Type>().value(row) as i64;
+            let date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap() + Duration::days(days);
+            Some(date.to_string())
+        }
+        DataType::Date64 => {
+            let ms = array.as_primitive::<arrow::array::types::Date64Type>().value(row);
+            let dt = DateTime::from_timestamp(ms / 1000, (ms % 1000 * 1_000_000) as u32).unwrap();
+            Some(dt.to_string())
+        }
+        DataType::Timestamp(unit, _) => {
+            let nanos: i128 = match unit {
+                TimeUnit::Second => array.as_primitive::<TimestampSecondType>().value(row) as i128 * 1_000_000_000,
+                TimeUnit::Millisecond => array.as_primitive::<TimestampMillisecondType>().value(row) as i128 * 1_000_000,
+                TimeUnit::Microsecond => array.as_primitive::<TimestampMicrosecondType>().value(row) as i128 * 1_000,
+                TimeUnit::Nanosecond => array.as_primitive::<TimestampNanosecondType>().value(row) as i128,
+            };
+            let secs = (nanos / 1_000_000_000) as i64;
+            let nsec = (nanos % 1_000_000_000) as u32;
+            let dt = DateTime::from_timestamp(secs, nsec).unwrap();
+            Some(dt.to_string())
+        }
+        DataType::List(_) => {
+            let list = array.as_any().downcast_ref::<ListArray>().unwrap();
+            let values = list.value(row);
+            let mut parts = Vec::new();
+            for i in 0..values.len() {
+                match arrow_value_to_string(values.as_ref(), i) {
+                    Some(v) => parts.push(v),
+                    None => parts.push("NULL".to_string()),
+                }
+            }
+            Some(format!("{{{}}}", parts.join(",")))
+        }
+        DataType::LargeList(_) => {
+            let list = array.as_any().downcast_ref::<LargeListArray>().unwrap();
+            let values = list.value(row);
+            let mut parts = Vec::new();
+            for i in 0..values.len() {
+                match arrow_value_to_string(values.as_ref(), i) {
+                    Some(v) => parts.push(v),
+                    None => parts.push("NULL".to_string()),
+                }
+            }
+            Some(format!("{{{}}}", parts.join(",")))
+        }
+        DataType::FixedSizeList(_, _) => {
+            let list = array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+            let values = list.value(row);
+            let mut parts = Vec::new();
+            for i in 0..values.len() {
+                match arrow_value_to_string(values.as_ref(), i) {
+                    Some(v) => parts.push(v),
+                    None => parts.push("NULL".to_string()),
+                }
+            }
+            Some(format!("{{{}}}", parts.join(",")))
+        }
+        _ => None,
+    }
+}
+
+fn arrow_list_to_vec(array: &dyn Array, row: usize) -> Vec<String> {
+    match array.data_type() {
+        DataType::List(_) => {
+            let list = array.as_any().downcast_ref::<ListArray>().unwrap();
+            let values = list.value(row);
+            (0..values.len())
+                .map(|i| arrow_value_to_string(values.as_ref(), i).unwrap_or_default())
+                .collect()
+        }
+        DataType::LargeList(_) => {
+            let list = array.as_any().downcast_ref::<LargeListArray>().unwrap();
+            let values = list.value(row);
+            (0..values.len())
+                .map(|i| arrow_value_to_string(values.as_ref(), i).unwrap_or_default())
+                .collect()
+        }
+        DataType::FixedSizeList(_, _) => {
+            let list = array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+            let values = list.value(row);
+            (0..values.len())
+                .map(|i| arrow_value_to_string(values.as_ref(), i).unwrap_or_default())
+                .collect()
+        }
+        _ => vec![],
+    }
+}
+
 fn encode_arrow_value(
     encoder: &mut DataRowEncoder,
     array: &dyn Array,
@@ -345,6 +455,10 @@ fn encode_arrow_value(
             let nsec = (nanos % 1_000_000_000) as u32;
             let dt = DateTime::from_timestamp(secs, nsec).unwrap();
             encoder.encode_field(&Some(dt))
+        }
+        DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _) => {
+            let vec = arrow_list_to_vec(array, row);
+            encoder.encode_field(&vec)
         }
         _ => encoder.encode_field(&Option::<&str>::None),
     }

--- a/src/pg/arrow_map.rs
+++ b/src/pg/arrow_map.rs
@@ -85,8 +85,14 @@ pub fn arrow_type_to_pgwire(dt: &DataType) -> Type {
         // | RunEndEncoded(_, _)
         // | Null                      => Type::VARCHAR,
 
+        /* ── arrays ─────────────────────────────── */
+        List(field) | LargeList(field) | FixedSizeList(field, _) => match field.data_type() {
+            DataType::Utf8 | DataType::LargeUtf8 => Type::VARCHAR_ARRAY,
+            _ => Type::VARCHAR,
+        },
+
         /* ── everything complex / unsupported ─── */
-        _=> Type::VARCHAR,
+        _ => Type::VARCHAR,
     }
 }
 

--- a/tests/test_pg_catalog_query.py
+++ b/tests/test_pg_catalog_query.py
@@ -97,6 +97,15 @@ class PgCatalogEnabledTest(unittest.TestCase):
             self.assertEqual(cur.fetchone()[0], 42)
         conn.close()
 
+    def test_current_schemas(self):
+        conn = psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        with conn.cursor() as cur:
+            cur.execute("SELECT current_schemas(true)")
+            row = cur.fetchone()
+            self.assertIsInstance(row[0], list)
+            self.assertGreater(len(row[0]), 0)
+        conn.close()
+
 
 class PgCatalogDisabledTest(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Summary
- convert arrow list columns to proper postgres arrays
- map Arrow list of strings to VARCHAR_ARRAY OID
- test that `current_schemas(true)` returns a list

## Testing
- `pytest tests/test_pg_catalog_query.py::PgCatalogEnabledTest::test_current_schemas -q`
- `pytest tests/test_server.py::ServerTest::test_simple_query -q`


------
https://chatgpt.com/codex/tasks/task_e_685b1fe3728c832f86783f473895c392