### PR TITLE
Update docs about returning errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ class Connection(riffq.BaseConnection):
 
 ```
 
+### Returning Errors from Python
+
+If a query fails you can report the error back to the client by sending
+an Arrow batch that describes the problem:
+
+```python
+except Exception as exc:
+    batch = self.arrow_batch(
+        [pa.array(["ERROR"]), pa.array([str(exc)])],
+        ["error", "message"],
+    )
+    self.send_reader(batch, callback)
+```
+
 ### Start the server
 
 ```python


### PR DESCRIPTION
## Summary
- describe how to return errors from Python to Postgres clients in `README.md`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862f137e498832f84131a4768491100