### PR TITLE
Add TLS options to Teleduck CLI

### DIFF
--- a/teleduck/README.md
+++ b/teleduck/README.md
@@ -9,3 +9,14 @@ teleduck mydata.db
 ```
 
 and connect with any PostgreSQL client.
+
+## TLS options
+
+Teleduck serves the PostgreSQL protocol over TLS by default. You can
+control TLS behaviour using the following options:
+
+* `--use-tls/--no-use-tls` – enable or disable TLS (default: enabled)
+* `--tls-cert-file` – path to a TLS certificate file. If not provided the
+  built in certificate is used.
+* `--tls-key-file` – path to the TLS private key file. If not provided the
+  built in key is used.

--- a/teleduck/src/teleduck/__main__.py
+++ b/teleduck/src/teleduck/__main__.py
@@ -18,14 +18,29 @@ import click
     multiple=True,
     help="SQL statement to run before starting the server",
 )
+@click.option("--use-tls/--no-use-tls", "use_tls", default=True, show_default=True, help="Use TLS for the server")
+@click.option("--tls-cert-file", default=None, type=click.Path(), help="Path to TLS certificate")
+@click.option("--tls-key-file", default=None, type=click.Path(), help="Path to TLS key")
 def main(
     db_file: str,
     host: str,
     port: int,
     sql_scripts: tuple[str, ...],
     sqls: tuple[str, ...],
+    use_tls: bool,
+    tls_cert_file: str | None,
+    tls_key_file: str | None,
 ):
-    run_server(db_file, port, host=host, sql_scripts=list(sql_scripts), sql=list(sqls))
+    run_server(
+        db_file,
+        port,
+        host=host,
+        sql_scripts=list(sql_scripts),
+        sql=list(sqls),
+        use_tls=use_tls,
+        tls_cert_file=tls_cert_file,
+        tls_key_file=tls_key_file,
+    )
 
 if __name__ == "__main__":
     main()

--- a/teleduck/tests/test_cli.py
+++ b/teleduck/tests/test_cli.py
@@ -11,7 +11,14 @@ class CliTest(unittest.TestCase):
             result = runner.invoke(main, ['my.db', '--host', '127.0.0.1', '--port', '9999'])
             self.assertEqual(result.exit_code, 0)
             mock_run_server.assert_called_once_with(
-                'my.db', 9999, host='127.0.0.1', sql_scripts=[], sql=[]
+                'my.db',
+                9999,
+                host='127.0.0.1',
+                sql_scripts=[],
+                sql=[],
+                use_tls=True,
+                tls_cert_file=None,
+                tls_key_file=None,
             )
 
     def test_cli_sql_options(self):
@@ -33,6 +40,33 @@ class CliTest(unittest.TestCase):
                 host='127.0.0.1',
                 sql_scripts=['init.sql', 'data.sql'],
                 sql=['INSERT INTO t VALUES (1)'],
+                use_tls=True,
+                tls_cert_file=None,
+                tls_key_file=None,
+            )
+
+    def test_cli_tls_options(self):
+        runner = CliRunner()
+        with patch('teleduck.__main__.run_server') as mock_run_server:
+            result = runner.invoke(
+                main,
+                [
+                    'my.db',
+                    '--no-use-tls',
+                    '--tls-cert-file', 'c.crt',
+                    '--tls-key-file', 'k.key',
+                ],
+            )
+            self.assertEqual(result.exit_code, 0)
+            mock_run_server.assert_called_once_with(
+                'my.db',
+                5433,
+                host='127.0.0.1',
+                sql_scripts=[],
+                sql=[],
+                use_tls=False,
+                tls_cert_file='c.crt',
+                tls_key_file='k.key',
             )
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add TLS options to Teleduck server and CLI
- document TLS options
- test CLI TLS options

## Testing
- `PYTHONPATH=$PWD/src pytest -q` in `teleduck`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6862f4d91590832facad57840af2ef01

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable TLS support for the server, including options to enable or disable TLS and specify custom certificate and key files via the command line.

* **Documentation**
  * Updated documentation to describe new TLS options and clarify default TLS behavior.

* **Tests**
  * Enhanced tests to cover new TLS configuration options and ensure correct behavior when using custom certificate and key files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->