### PR TITLE
Support custom errors in auth/connect callbacks

### DIFF
--- a/tests/test_on_authentication_custom_error.py
+++ b/tests/test_on_authentication_custom_error.py
@@ -1,0 +1,55 @@
+import multiprocessing
+import socket
+import time
+import unittest
+import psycopg
+from helpers import _ensure_riffq_built
+
+
+def _run_server(port: int):
+    import riffq
+    from riffq.helpers import to_arrow
+
+    def handle_query(sql, callback, **kwargs):
+        callback(to_arrow([{"name": "val", "type": "int"}], [[1]]))
+
+    def handle_auth(conn_id, user, password, host, *, callback, database=None):
+        callback(False, "no", "FATAL", "28P01")
+
+    server = riffq.Server(f"127.0.0.1:{port}")
+    server.on_query(handle_query)
+    server.on_authentication(handle_auth)
+    server.start()
+
+
+class AuthenticationErrorTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_riffq_built()
+        cls.port = 55452
+        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port,), daemon=True)
+        cls.proc.start()
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            cls.proc.terminate()
+            cls.proc.join()
+            raise RuntimeError("Server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+
+    def test_auth_error(self):
+        with self.assertRaises(psycopg.OperationalError) as ctx:
+            psycopg.connect(f"postgresql://user:secret@127.0.0.1:{self.port}/db")
+        self.assertIn("no", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_on_connect_custom_error.py
+++ b/tests/test_on_connect_custom_error.py
@@ -1,0 +1,54 @@
+import multiprocessing
+import socket
+import time
+import unittest
+import psycopg
+from helpers import _ensure_riffq_built
+
+
+def _run_server(port: int):
+    import riffq
+
+    def handle_query(sql, callback, **kwargs):
+        callback(([{"name": "val", "type": "int"}], [[1]]))
+
+    def handle_connect(conn_id, ip, port, *, callback):
+        callback(False, "nope", "FATAL", "28000")
+
+    server = riffq.Server(f"127.0.0.1:{port}")
+    server.on_query(handle_query)
+    server.on_connect(handle_connect)
+    server.start()
+
+
+class OnConnectErrorTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        _ensure_riffq_built()
+        cls.port = 55450
+        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port,), daemon=True)
+        cls.proc.start()
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            cls.proc.terminate()
+            cls.proc.join()
+            raise RuntimeError("Server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.join()
+
+    def test_reject_custom_error(self):
+        with self.assertRaises(psycopg.OperationalError) as ctx:
+            psycopg.connect(f"postgresql://user@127.0.0.1:{self.port}/db")
+        self.assertIn("nope", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow returning detailed errors from connect and authentication callbacks
- add Python tests for new error customization

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68639e0d74cc832f8aa8804e09231173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced connection and authentication error handling to provide detailed error messages and codes to clients.
  * Custom error information from Python callbacks is now sent back to clients during connection and authentication failures.

* **Tests**
  * Added tests to verify custom error propagation for both authentication and connection failures, ensuring clients receive the correct error messages and codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->