### PR TITLE
Add Teleduck PyPI release workflow

### DIFF
--- a/.github/workflows/release-teleduck.yml
+++ b/.github/workflows/release-teleduck.yml
@@ -1,0 +1,29 @@
+name: release-teleduck
+
+on:
+  push:
+    tags:
+      - 'release-teleduck-*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install build tool
+        run: pip install build
+      - name: Build teleduck package
+        run: |
+          cd teleduck
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: teleduck/dist
+          skip-existing: true

--- a/teleduck/tests/test_cli.py
+++ b/teleduck/tests/test_cli.py
@@ -1,7 +1,11 @@
 import unittest
 from unittest.mock import patch
 from click.testing import CliRunner
+from pathlib import Path
+import sys
 
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root / "src"))
 from teleduck.__main__ import main
 
 class CliTest(unittest.TestCase):

--- a/teleduck/tests/test_duckdb_catalog.py
+++ b/teleduck/tests/test_duckdb_catalog.py
@@ -10,7 +10,11 @@ import duckdb
 
 def _run_server(db_file: str, port: int):
     import sys
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root / "src"))
+    for mod in ["teleduck.server", "teleduck"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
     from teleduck.server import run_server
     run_server(db_file, port)
 

--- a/teleduck/tests/test_sql_init.py
+++ b/teleduck/tests/test_sql_init.py
@@ -10,7 +10,11 @@ import unittest
 
 def _run_server(db_file: str, port: int, scripts, sqls):
     import sys
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root / "src"))
+    for mod in ["teleduck.server", "teleduck"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
     from teleduck.server import run_server
     run_server(db_file, port, sql_scripts=scripts, sql=sqls)
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish Teleduck to PyPI when a `release-teleduck-*` tag is pushed
- adjust Teleduck tests to load package from source so they pass with the new workflow

## Testing
- `python -m unittest discover -s teleduck/tests`


------
https://chatgpt.com/codex/tasks/task_e_6863c14397f0832fa9f5ad08264d8641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a new automated workflow to build and publish packages to PyPI upon release.
* **Tests**
  * Improved test setup to ensure local source code is used during testing, preventing interference from installed packages or cached modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->