### PR TITLE
Add teleduck release prep script and package certs

### DIFF
--- a/prep-release-teleduck.sh
+++ b/prep-release-teleduck.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# for example release-0.1.3-dev20250623+1
+export GITHUB_REF_NAME=$1
+python -c "import os,re,pathlib;v=os.environ['GITHUB_REF_NAME'][len('release-'):];p=pathlib.Path('teleduck/pyproject.toml');p.write_text(re.sub(r'^version\\s*=.*$',f'version = \"{v}\"',p.read_text(),flags=re.M))"
+git add teleduck/pyproject.toml
+git commit -m "release: ${GITHUB_REF_NAME}"
+git tag $GITHUB_REF_NAME
+git push origin main --tags

--- a/teleduck/pyproject.toml
+++ b/teleduck/pyproject.toml
@@ -14,6 +14,10 @@ dependencies = [
     "click",
     "riffq",
 ]
+packages = [{ include = "teleduck", from = "src" }]
 
 [project.scripts]
 teleduck = "teleduck.__main__:main"
+
+[tool.setuptools.package-data]
+teleduck = ["certs/*"]


### PR DESCRIPTION
## Summary
- add `prep-release-teleduck.sh` for bumping version in teleduck's `pyproject.toml`
- include `certs` folder in teleduck package

## Testing
- `pip install -e .`
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d20ba1e8832f8e054062c0c346ae