### PR TITLE
Add Teleduck authentication and package certs

### DIFF
--- a/teleduck/README.md
+++ b/teleduck/README.md
@@ -20,3 +20,15 @@ control TLS behaviour using the following options:
   built in certificate is used.
 * `--tls-key-file` – path to the TLS private key file. If not provided the
   built in key is used.
+
+## Authentication
+
+Teleduck accepts any username and password by default. Set the following
+environment variables to enable credential checks:
+
+* `TELEDUCK_USERNAME` – expected username
+* `TELEDUCK_PASSWORD` – expected password
+* `TELEDUCK_PASSWORD_SHA1` – SHA1 hash of the expected password
+
+If none of these variables are defined, authentication succeeds for any
+credentials.

--- a/teleduck/pyproject.toml
+++ b/teleduck/pyproject.toml
@@ -17,3 +17,11 @@ dependencies = [
 
 [project.scripts]
 teleduck = "teleduck.__main__:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages = ["teleduck"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+teleduck = ["certs/*"]


### PR DESCRIPTION
## Summary
- package default certs in Teleduck build
- allow username/password authentication via environment variables
- document authentication settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'riffq')*
- `pip install -r requirements.txt`
- `pip install -e .` *(failed to build editable package)*

------
https://chatgpt.com/codex/tasks/task_e_6863e6c12c34832f9397e914e1b32bb5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced environment-variable-based authentication, allowing you to restrict access by setting username and password (or password SHA1 hash) through environment variables.

* **Documentation**
  * Updated the README to explain the new authentication options and how to configure them.

* **Chores**
  * Adjusted packaging configuration to ensure certificate files are included during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->