### PR TITLE
Add read-only option to teleduck

### DIFF
--- a/teleduck/README.md
+++ b/teleduck/README.md
@@ -31,6 +31,8 @@ teleduck [OPTIONS] DB_FILE
   in certificate is used.
 * `--tls-key-file` – path to the TLS private key file. If not provided the built
   in key is used.
+* `--read-only/--no-read-only` – open the database in read-only mode
+  (default: disabled).
 
 ### Generating certificates
 

--- a/teleduck/src/teleduck/__main__.py
+++ b/teleduck/src/teleduck/__main__.py
@@ -21,6 +21,7 @@ import click
 @click.option("--use-tls/--no-use-tls", "use_tls", default=True, show_default=True, help="Use TLS for the server")
 @click.option("--tls-cert-file", default=None, type=click.Path(), help="Path to TLS certificate")
 @click.option("--tls-key-file", default=None, type=click.Path(), help="Path to TLS key")
+@click.option("--read-only/--no-read-only", "read_only", default=False, show_default=True, help="Open database in read-only mode")
 def main(
     db_file: str,
     host: str,
@@ -30,6 +31,7 @@ def main(
     use_tls: bool,
     tls_cert_file: str | None,
     tls_key_file: str | None,
+    read_only: bool,
 ):
     run_server(
         db_file,
@@ -40,6 +42,7 @@ def main(
         use_tls=use_tls,
         tls_cert_file=tls_cert_file,
         tls_key_file=tls_key_file,
+        read_only=read_only,
     )
 
 if __name__ == "__main__":

--- a/teleduck/src/teleduck/server.py
+++ b/teleduck/src/teleduck/server.py
@@ -136,6 +136,7 @@ def run_server(
     use_tls: bool = True,
     tls_cert_file: Optional[str] = None,
     tls_key_file: Optional[str] = None,
+    read_only: bool = False,
 ):
     """Start the teleduck server using the given DuckDB database file.
 
@@ -159,9 +160,11 @@ def run_server(
         will be used.
     tls_key_file:
         Path to the TLS key. If not provided, the built-in key will be used.
+    read_only:
+        Open the DuckDB database in read-only mode.
     """
     global duckdb_con
-    duckdb_con = duckdb.connect(db_file)
+    duckdb_con = duckdb.connect(db_file, read_only=read_only)
 
     # execute initialization SQL before starting the server
     if sql_scripts:
@@ -232,7 +235,8 @@ if __name__ == "__main__":
     @click.option("--use-tls/--no-use-tls", "use_tls", default=True, show_default=True, help="Use TLS for the server")
     @click.option("--tls-cert-file", default=None, type=click.Path(), help="Path to TLS certificate")
     @click.option("--tls-key-file", default=None, type=click.Path(), help="Path to TLS key")
-    def _main(db_file: str, port: int, use_tls: bool, tls_cert_file: str | None, tls_key_file: str | None):
-        run_server(db_file, port, use_tls=use_tls, tls_cert_file=tls_cert_file, tls_key_file=tls_key_file)
+    @click.option("--read-only/--no-read-only", "read_only", default=False, show_default=True, help="Open database in read-only mode")
+    def _main(db_file: str, port: int, use_tls: bool, tls_cert_file: str | None, tls_key_file: str | None, read_only: bool):
+        run_server(db_file, port, use_tls=use_tls, tls_cert_file=tls_cert_file, tls_key_file=tls_key_file, read_only=read_only)
 
     _main()

--- a/teleduck/tests/test_cli.py
+++ b/teleduck/tests/test_cli.py
@@ -23,6 +23,7 @@ class CliTest(unittest.TestCase):
                 use_tls=True,
                 tls_cert_file=None,
                 tls_key_file=None,
+                read_only=False,
             )
 
     def test_cli_sql_options(self):
@@ -47,6 +48,7 @@ class CliTest(unittest.TestCase):
                 use_tls=True,
                 tls_cert_file=None,
                 tls_key_file=None,
+                read_only=False,
             )
 
     def test_cli_tls_options(self):
@@ -71,6 +73,24 @@ class CliTest(unittest.TestCase):
                 use_tls=False,
                 tls_cert_file='c.crt',
                 tls_key_file='k.key',
+                read_only=False,
+            )
+
+    def test_cli_read_only_option(self):
+        runner = CliRunner()
+        with patch('teleduck.__main__.run_server') as mock_run_server:
+            result = runner.invoke(main, ['my.db', '--read-only'])
+            self.assertEqual(result.exit_code, 0)
+            mock_run_server.assert_called_once_with(
+                'my.db',
+                5433,
+                host='127.0.0.1',
+                sql_scripts=[],
+                sql=[],
+                use_tls=True,
+                tls_cert_file=None,
+                tls_key_file=None,
+                read_only=True,
             )
 
 if __name__ == '__main__':

--- a/teleduck/tests/test_duckdb_catalog.py
+++ b/teleduck/tests/test_duckdb_catalog.py
@@ -16,7 +16,7 @@ def _run_server(db_file: str, port: int):
         if mod in sys.modules:
             del sys.modules[mod]
     from teleduck.server import run_server
-    run_server(db_file, port)
+    run_server(db_file, port, read_only=False)
 
 
 class DuckDbCatalogTest(unittest.TestCase):

--- a/teleduck/tests/test_read_only.py
+++ b/teleduck/tests/test_read_only.py
@@ -1,0 +1,17 @@
+import unittest
+from unittest.mock import patch
+from pathlib import Path
+import sys
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root / "src"))
+from teleduck.server import run_server
+
+class ReadOnlyTest(unittest.TestCase):
+    def test_duckdb_connection_read_only(self):
+        with patch('duckdb.connect') as mock_connect:
+            run_server('db.db', port=1111, read_only=True)
+            mock_connect.assert_called_once_with('db.db', read_only=True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/teleduck/tests/test_sql_init.py
+++ b/teleduck/tests/test_sql_init.py
@@ -16,7 +16,7 @@ def _run_server(db_file: str, port: int, scripts, sqls):
         if mod in sys.modules:
             del sys.modules[mod]
     from teleduck.server import run_server
-    run_server(db_file, port, sql_scripts=scripts, sql=sqls)
+    run_server(db_file, port, sql_scripts=scripts, sql=sqls, read_only=False)
 
 
 class SqlInitTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add `--read-only/--no-read-only` flag to Teleduck CLI and server
- open DuckDB connection in read-only mode when flag is used
- document the new flag in Teleduck README
- test the read-only flag and update existing tests

## Testing
- `pytest teleduck/tests/test_cli.py teleduck/tests/test_duckdb_catalog.py teleduck/tests/test_sql_init.py teleduck/tests/test_read_only.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f15378b0832f83523a57830a7c89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line option to start the server in read-only mode, allowing the database to be opened without write access.

* **Documentation**
  * Updated CLI documentation to describe the new read-only option.

* **Tests**
  * Added and updated tests to verify correct behavior when using the read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->