### PR TITLE
Fix teleduck test discovery path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,5 @@ jobs:
       - name: Run concurrency unit tests
         run: python -m unittest discover -s test_concurrency
       - name: Run teleduck unit tests
-        run: python -m unittest discover -s teleduck -p 'test_*.py'
+        run: python -m unittest discover -s teleduck/tests -p 'test_*.py'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   unit-tests:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Cache cargo registry
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  # push:
-  #   branches: ["**"]
+  push:
+    branches: ["**"]
   pull_request: 
     branches: ["**"]
 
@@ -32,6 +32,7 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Run Rust tests
         run: cargo test --verbose
       - name: Cache pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unit-tests:
-    timeout-minutes: 15
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches: ["**"]
+  # push:
+  #   branches: ["**"]
   pull_request: 
     branches: ["**"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "riffq"
-version = "0.1.3"
+version = "0.1.6"
 dependencies = [
  "arrow",
  "arrow-schema",

--- a/teleduck/tests/test_read_only.py
+++ b/teleduck/tests/test_read_only.py
@@ -10,7 +10,7 @@ from teleduck.server import run_server
 class ReadOnlyTest(unittest.TestCase):
     def test_duckdb_connection_read_only(self):
         with patch('duckdb.connect') as mock_connect:
-            with patch('riffq.RiffqServer.start'):
+            with patch('teleduck.server.riffq.RiffqServer.start'):
                 run_server('db.db', port=1111, read_only=True)
                 mock_connect.assert_called_once_with('db.db', read_only=True)
 

--- a/teleduck/tests/test_read_only.py
+++ b/teleduck/tests/test_read_only.py
@@ -10,8 +10,9 @@ from teleduck.server import run_server
 class ReadOnlyTest(unittest.TestCase):
     def test_duckdb_connection_read_only(self):
         with patch('duckdb.connect') as mock_connect:
-            run_server('db.db', port=1111, read_only=True)
-            mock_connect.assert_called_once_with('db.db', read_only=True)
+            with patch('riffq.RiffqServer.start'):
+                run_server('db.db', port=1111, read_only=True)
+                mock_connect.assert_called_once_with('db.db', read_only=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure the CI workflow discovers teleduck tests from the correct directory

## Testing
- python -m unittest discover -s teleduck/tests -p 'test_*.py' *(hangs at ReadOnlyTest; interrupted after confirming discovery works)*

------
https://chatgpt.com/codex/tasks/task_e_68cc381ad7a8832fa9895f59d3d63877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by mocking server startup in a unit test to avoid side effects while preserving assertions.
  * Adjusted test discovery so unit tests are found and run reliably.

* **Chores**
  * Increased CI job timeout to reduce premature job failures.
  * Updated CI caching step to improve workflow reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->