### PR TITLE
Don't let a silent client wedge the accept loop (+ accept() error handling, PKCS#1 TLS keys)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use tokio::net::TcpStream;
 use pyo3::types::{PyDict, PyList, PyTuple, PyCapsule};
 use std::fs::File;
 use std::io::{BufReader, Error as IOError, ErrorKind};
-use rustls_pemfile::{certs, pkcs8_private_keys};
+use rustls_pemfile::{certs, private_key};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 use tokio_rustls::rustls::ServerConfig;
 use tokio_rustls::TlsAcceptor;
@@ -1672,11 +1672,21 @@ impl PgWireServerHandlers for RiffqProcessorFactory {
     }
 }
 
+/// How long to wait for a client's first bytes when sniffing for a GSSAPI
+/// encryption request. Well-behaved clients send SSLRequest/StartupMessage
+/// immediately after connecting; on timeout the socket is handed to the
+/// protocol handler untouched.
+const GSSENCMODE_DETECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 async fn detect_gssencmode(mut socket: TcpStream) -> Option<TcpStream> {
     let mut buf = [0u8; 8];
 
-    if let Ok(n) = socket.peek(&mut buf).await {
-        if n == 8 {
+    // peek() waits until the client sends something, so it must be bounded:
+    // a client that connects and stays silent would otherwise pin this future
+    // until the peer goes away -- potentially forever if the peer vanishes
+    // without FIN/RST.
+    match tokio::time::timeout(GSSENCMODE_DETECT_TIMEOUT, socket.peek(&mut buf)).await {
+        Ok(Ok(n)) if n == 8 => {
             let request_code = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]);
             if request_code == 80877104 {
                 if let Err(e) = socket.read_exact(&mut buf).await {
@@ -1687,6 +1697,10 @@ async fn detect_gssencmode(mut socket: TcpStream) -> Option<TcpStream> {
                 }
             }
         }
+        Ok(_) => {}
+        Err(_) => {
+            debug!("no data within gssencmode detection window; continuing without GSSAPI sniffing");
+        }
     }
 
     Some(socket)
@@ -1696,10 +1710,15 @@ fn setup_tls(cert_path: &str, key_path: &str) -> Result<TlsAcceptor, IOError> {
     let cert = certs(&mut BufReader::new(File::open(cert_path)?))
         .collect::<Result<Vec<CertificateDer>, IOError>>()?;
 
-    let key = pkcs8_private_keys(&mut BufReader::new(File::open(key_path)?))
-        .map(|key| key.map(PrivateKeyDer::from))
-        .collect::<Result<Vec<PrivateKeyDer>, IOError>>()?
-        .remove(0);
+    // private_key() understands PKCS#8, PKCS#1 and SEC1 PEM. The previous
+    // pkcs8-only parse produced an empty Vec for e.g. "BEGIN RSA PRIVATE KEY"
+    // files, and the .remove(0) panicked -- which, through pyo3, killed the
+    // calling thread instead of raising a catchable error.
+    let key: PrivateKeyDer = private_key(&mut BufReader::new(File::open(key_path)?))?
+        .ok_or_else(|| IOError::new(
+            ErrorKind::InvalidInput,
+            format!("no PEM private key found in {key_path} (expected PKCS#8, PKCS#1 or SEC1)"),
+        ))?;
 
     let mut config = ServerConfig::builder()
         .with_no_client_auth()
@@ -2215,8 +2234,20 @@ impl Server {
                 let server_version = server_version.clone();
                 async move {
                     loop {
-                        let (socket, addr) = listener.accept().await.unwrap();
-                        if let Some(socket) = detect_gssencmode(socket).await {
+                        // accept() fails transiently (EMFILE/ENFILE on fd
+                        // exhaustion, ECONNABORTED, ...). Panicking here via
+                        // unwrap() killed the accept task and dropped the
+                        // listener: the process kept running but the port
+                        // stayed dead until a restart.
+                        let (socket, addr) = match listener.accept().await {
+                            Ok(conn) => conn,
+                            Err(e) => {
+                                error!("Failed to accept connection: {:?}; retrying", e);
+                                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                                continue;
+                            }
+                        };
+                        {
                             let conn_ctx = SessionContext::new_with_state(
                                 default_ctx.state().clone(),
                             );
@@ -2249,6 +2280,17 @@ impl Server {
                             let port = addr.port();
                             
                             tokio::spawn(async move {
+                                // detect_gssencmode waits for the client's first
+                                // bytes, so it must run inside the per-connection
+                                // task. When it was awaited inline in the accept
+                                // loop, a single client that connected and never
+                                // sent anything blocked ALL accepts: the kernel
+                                // kept completing handshakes into the listen
+                                // backlog, but no connection was ever served.
+                                let socket = match detect_gssencmode(socket).await {
+                                    Some(socket) => socket,
+                                    None => return,
+                                };
                                 if let Err(e) = process_socket(socket, tls_acceptor_ref, factory).await {
                                     error!("process_socket error: {:?}", e);
                                 }

--- a/tests/test_silent_client.py
+++ b/tests/test_silent_client.py
@@ -1,0 +1,86 @@
+"""Regression test: a client that connects and never sends a byte must not
+block other connections.
+
+detect_gssencmode() used to be awaited inline in the accept loop, so its
+peek() on a silent socket wedged ALL accepts: the kernel kept completing TCP
+handshakes into the listen backlog, but no connection was ever served (no
+SSLRequest reply, CLOSE_WAIT pile-up) until the process was restarted. This
+caused a multi-day production outage for a riffq user; see the PR that
+introduced this test.
+"""
+import multiprocessing
+import socket
+import time
+
+import psycopg
+import unittest
+from helpers import stop_server
+
+
+def _run_server(port: int):
+    import riffq
+    from riffq.helpers import to_arrow
+
+    def handle_query(sql, callback, **kwargs):
+        callback(to_arrow([{"name": "val", "type": "int"}], [[1]]))
+
+    server = riffq.Server(f"127.0.0.1:{port}")
+    server.on_query(handle_query)
+    server.start()
+
+
+class SilentClientTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.port = 55447
+        cls.proc = multiprocessing.Process(target=_run_server, args=(cls.port,), daemon=True)
+        cls.proc.start()
+
+        start = time.time()
+        while time.time() - start < 10:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", cls.port)) == 0:
+                    break
+            time.sleep(0.1)
+        else:
+            stop_server(cls.proc)
+            raise RuntimeError("server did not start")
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_server(cls.proc)
+
+    def _query_ok(self, timeout: int = 5) -> bool:
+        with psycopg.connect(
+            f"host=127.0.0.1 port={self.port} user=user password=secret dbname=db",
+            connect_timeout=timeout,
+        ) as conn:
+            with conn.cursor() as cur:
+                cur.execute("select 1")
+                return cur.fetchone()[0] == 1
+
+    def test_silent_connection_does_not_block_other_clients(self):
+        # Baseline: the server answers a normal client.
+        self.assertTrue(self._query_ok())
+
+        # Open a connection and send NOTHING. Before the fix this parked the
+        # accept loop inside detect_gssencmode()'s unbounded peek().
+        silent = socket.create_connection(("127.0.0.1", self.port))
+        try:
+            time.sleep(0.5)
+            # A normal client must still be served while the silent
+            # connection is held open.
+            self.assertTrue(self._query_ok())
+
+            # And several times in a row, to be sure we aren't racing.
+            for _ in range(3):
+                self.assertTrue(self._query_ok())
+        finally:
+            silent.close()
+
+        # Still healthy after the silent client goes away.
+        self.assertTrue(self._query_ok())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I run riffq behind a public :5432 (dbfor.dev) and hit a nasty failure mode: the port stopped speaking postgres for days while the process looked perfectly healthy. TCP connects still succeeded, but SSLRequest never got a reply, and inside the pod we found ~1000 CLOSE_WAIT sockets and a saturated listen backlog. A restart fixed it instantly.

The cause is that detect_gssencmode() is awaited inline in the accept loop, and its peek() has no timeout. Any client that connects and never sends a byte (port scanner, NAT peer that vanished without FIN) parks the accept loop forever. The kernel keeps completing handshakes into the backlog so the port looks open from outside, but nothing is ever served. It's trivially reproducible: open a socket to the server, send nothing, and try to connect with psql from another terminal.

This PR does three things:

- moves detect_gssencmode() into the per-connection task and bounds its peek() with a 10s timeout (on timeout the socket just proceeds to the protocol handler untouched, so slow-but-legit clients are unaffected)
- replaces `listener.accept().await.unwrap()` with logged retry + short backoff, since accept() fails transiently under fd exhaustion (EMFILE) and the panic kills the accept task and drops the listener for good
- makes setup_tls() use rustls_pemfile::private_key() so PKCS#1 ("BEGIN RSA PRIVATE KEY") and SEC1 keys work. Previously pkcs8_private_keys() returned an empty vec for those and .remove(0) panicked — and through pyo3 that panic kills the calling thread silently rather than raising, which is how our TLS misconfig turned into "server up, port dead"

There's a regression test (tests/test_silent_client.py) that holds a silent connection open and asserts other clients still get served. It fails on main (psycopg times out) and passes with this change. Existing tests (test_server, test_server_tls, test_connection_id) and cargo test still pass, and I verified a PKCS#1 key now loads while a garbage key file raises a catchable OSError.

I used Fable to create the PR
